### PR TITLE
Introduce Widget Posts functionality

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,1 +1,9 @@
-dev-lib/.jscsrc
+{
+	"preset": "wordpress",
+	"excludeFiles": [
+		"**/vendor/**",
+		"**.min.js",
+		"**/node_modules/**",
+		"core-patched/wp-admin/js/widgets.js"
+	]
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,9 +1,1 @@
-{
-	"preset": "wordpress",
-	"excludeFiles": [
-		"**/vendor/**",
-		"**.min.js",
-		"**/node_modules/**",
-		"core-patched/wp-admin/js/widgets.js"
-	]
-}
+dev-lib/.jscsrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,12 @@ node_js:
     - 0.10
 
 env:
-    - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=latest WP_MULTISITE=1
+    - WP_VERSION=trunk WP_MULTISITE=1
 
 before_script:
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - source $DEV_LIB_PATH/travis.before_script.sh
-    - svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/tests/ $WP_TESTS_DIR/tests/
-    - mkdir -p $WP_TESTS_DIR/data/
 
 script:
     - $DEV_LIB_PATH/travis.script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - source $DEV_LIB_PATH/travis.before_script.sh
     - svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/tests/ $WP_TESTS_DIR/tests/
+    - mkdir -p $WP_TESTS_DIR/data/
 
 script:
     - $DEV_LIB_PATH/travis.script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
     - source $DEV_LIB_PATH/travis.before_script.sh
+    - svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/tests/ $WP_TESTS_DIR/tests/
 
 script:
     - $DEV_LIB_PATH/travis.script.sh

--- a/php/class-base-test-case.php
+++ b/php/class-base-test-case.php
@@ -18,11 +18,12 @@ abstract class Base_Test_Case extends \WP_UnitTestCase {
 	}
 
 	function clean_up_global_scope() {
-		global $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
+		global $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates, $wp_post_types;
 		// @codingStandardsIgnoreStart
 		$wp_registered_sidebars = $wp_registered_widgets = $wp_registered_widget_controls = $wp_registered_widget_updates = array();
 		// @codingStandardsIgnoreEnd
 		$this->plugin->widget_factory->widgets = array();
+		unset( $wp_post_types[ Widget_Posts::INSTANCE_POST_TYPE ] );
 		parent::clean_up_global_scope();
 	}
 

--- a/php/class-efficient-multidimensional-setting-sanitizing.php
+++ b/php/class-efficient-multidimensional-setting-sanitizing.php
@@ -65,7 +65,8 @@ class Efficient_Multidimensional_Setting_Sanitizing {
 		$this->manager->efficient_multidimensional_setting_sanitizing = $this;
 
 		add_filter( 'customize_dynamic_setting_class', array( $this, 'filter_dynamic_setting_class' ), 10, 2 );
-		add_action( 'widgets_init', array( $this, 'save_widget_objs' ), 90 );
+		$priority = 92; // Because Widget_Posts::prepare_widget_data() happens at 91.
+		add_action( 'widgets_init', array( $this, 'capture_widget_instance_data' ), $priority );
 
 		// Note that customize_register happens at wp_loaded, so we register the settings just before
 		$priority = has_action( 'wp_loaded', array( $this->manager, 'wp_loaded' ) );
@@ -80,15 +81,46 @@ class Efficient_Multidimensional_Setting_Sanitizing {
 	 * Since at widgets_init,100 the single instances of widgets get copied out
 	 * to the many instances in $wp_registered_widgets, we capture all of the
 	 * registered widgets up front so we don't have to search through the big
-	 * list later.
+	 * list later. At this time we also add the pre_option filter to use the
+	 * settings as retrieved once from the database, and then manipulated in a
+	 * pre-unserialized data structure ready to be re-serialized once when the
+	 * Customizer setting is saved.
 	 *
 	 * @see WP_Customize_Widget_Setting::__construct()
+	 * @see Widget_Posts::filter_pre_option_widget_settings()
 	 */
-	function save_widget_objs() {
+	function capture_widget_instance_data() {
 		foreach ( $this->plugin->widget_factory->widgets as $widget_obj ) {
 			/** @var \WP_Widget $widget_obj */
 			$this->widget_objs[ $widget_obj->id_base ] = $widget_obj;
+
+			// Store the widget settings once, after Widget_Posts::prepare_widget_data() has run, so we can get Widget_Settings ArrayIterators.
+			$this->current_widget_type_values[ $widget_obj->id_base ] = $widget_obj->get_settings();
+
+			// Note that this happens _before_ Widget_Posts::filter_pre_option_widget_settings().
+			add_filter( "pre_option_widget_{$widget_obj->id_base}", function ( $pre_value ) use ( $widget_obj ) {
+				return $this->filter_pre_option_widget_settings( $pre_value, $widget_obj );
+			} );
 		}
+	}
+
+	/**
+	 * Pre-option filter which intercepts the expensive WP_Customize_Setting::_preview_filter().
+	 *
+	 * @see WP_Customize_Setting::_preview_filter()
+	 * @param null|array $pre_value Value that, if set, short-circuits the normal get_option() return value.
+	 * @param \WP_Widget $widget_obj
+	 * @return array
+	 * @throws Exception
+	 */
+	function filter_pre_option_widget_settings( $pre_value, $widget_obj ) {
+		if ( ! $this->disabled_filtering_pre_option_widget_settings ) {
+			if ( ! isset( $this->current_widget_type_values[ $widget_obj->id_base ] ) ) {
+				throw new Exception( "current_widget_type_values not set yet for $widget_obj->id_base" );
+			}
+			$pre_value = $this->current_widget_type_values[ $widget_obj->id_base ];
+		}
+		return $pre_value;
 	}
 
 	/**
@@ -142,6 +174,7 @@ class Efficient_Multidimensional_Setting_Sanitizing {
 	function register_widget_settings() {
 		global $wp_registered_widgets;
 		if ( empty( $wp_registered_widgets ) ) {
+			$this->plugin->trigger_warning( '$wp_registered_widgets is empty.' );
 			return;
 		}
 

--- a/php/class-widget-number-incrementing.php
+++ b/php/class-widget-number-incrementing.php
@@ -82,7 +82,14 @@ class Widget_Number_Incrementing {
 	function get_max_existing_widget_number( $id_base ) {
 		$widget_obj = $this->widget_objs[ $id_base ];
 		// @todo There should be a pre_existing_widget_numbers, pre_max_existing_widget_number filter, or pre_existing_widget_ids to short circuit the expensive WP_Widget::get_settings()
-		$widget_numbers = array_keys( $widget_obj->get_settings() );
+
+		$settings = $widget_obj->get_settings();
+		if ( $settings instanceof \ArrayAccess && method_exists( $settings, 'getArrayCopy' ) ) {
+			/** @see Widget_Settings */
+			$settings = $settings->getArrayCopy( $settings );
+		}
+
+		$widget_numbers = array_keys( $settings );
 		$widget_numbers[] = 2; // multi-widgets start numbering at 2
 		return max( $widget_numbers );
 	}

--- a/php/class-widget-number-incrementing.php
+++ b/php/class-widget-number-incrementing.php
@@ -135,13 +135,16 @@ class Widget_Number_Incrementing {
 	 */
 	function set_widget_number( $id_base, $number ) {
 		$this->add_widget_number_option( $id_base );
+		$existing_number = $this->get_widget_number( $id_base );
 		$number = max(
 			2, // multi-widget numbering starts here
 			$this->get_widget_number( $id_base ),
 			$this->get_max_existing_widget_number( $id_base ),
 			$number
 		);
-		update_option( $this->get_option_key_for_widget_number( $id_base ), $number );
+		if ( $existing_number !== $number ) {
+			update_option( $this->get_option_key_for_widget_number( $id_base ), $number );
+		}
 		return $number;
 	}
 

--- a/php/class-widget-number-incrementing.php
+++ b/php/class-widget-number-incrementing.php
@@ -25,7 +25,7 @@ class Widget_Number_Incrementing {
 	/**
 	 * @var \WP_Widget[]
 	 */
-	public $widget_objs = array();
+	public $widget_objs;
 
 	/**
 	 * @param Plugin $plugin
@@ -33,10 +33,25 @@ class Widget_Number_Incrementing {
 	function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
 
+		add_action( 'widgets_init', array( $this, 'store_widget_objects' ), 90 );
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, array( $this, 'ajax_incr_widget_number' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_filter( 'customize_refresh_nonces', array( $this, 'filter_customize_refresh_nonces' ) );
+	}
+
+	/**
+	 * @action widgets_init, 90
+	 */
+	function store_widget_objects() {
+		$this->widget_objs = array();
+		foreach ( $this->plugin->widget_factory->widgets as $widget_obj ) {
+			/** @var \WP_Widget $widget_obj */
+			if ( "widget_{$widget_obj->id_base}" !== $widget_obj->option_name ) {
+				continue;
+			}
+			$this->widget_objs[ $widget_obj->id_base ] = $widget_obj;
+		}
 	}
 
 	/**
@@ -65,8 +80,7 @@ class Widget_Number_Incrementing {
 	 * @return int
 	 */
 	function get_max_existing_widget_number( $id_base ) {
-		$widget_objs = $this->plugin->get_registered_widget_objects();
-		$widget_obj = $widget_objs[ $id_base ];
+		$widget_obj = $this->widget_objs[ $id_base ];
 		// @todo There should be a pre_existing_widget_numbers, pre_max_existing_widget_number filter, or pre_existing_widget_ids to short circuit the expensive WP_Widget::get_settings()
 		$widget_numbers = array_keys( $widget_obj->get_settings() );
 		$widget_numbers[] = 2; // multi-widgets start numbering at 2

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -176,8 +176,9 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 * @param array [$args]
 	 * @param array $assoc_args
 	 * @synopsis <widget_id>
+	 * @alias show
 	 */
-	public function show( $args, $assoc_args ) {
+	public function get( $args, $assoc_args ) {
 		try {
 			$widget_id = array_shift( $args );
 			unset( $assoc_args );

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -156,13 +156,10 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 		} catch ( \Exception $e ) {
 			\WP_CLI::error( sprintf( '%s: %s', get_class( $e ), $e->getMessage() ) );
 		}
-
 	}
 
 	/**
 	 * Import widget instances from a JSON dump mapping widget IDs (e.g. {"search-123":{"title":"Buscar"} }.
-	 *
-	 *
 	 */
 	public function import() {
 		\WP_CLI::error( 'Not implemented.' );

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -24,7 +24,7 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * @return Widget_Posts
 	 */
-	public function get_widget_posts() {
+	protected function get_widget_posts() {
 		if ( ! isset( static::$plugin_instance->widget_posts ) ) {
 			static::$plugin_instance->widget_posts = new Widget_Posts( static::$plugin_instance );
 		}

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -35,10 +35,10 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 * Enable looking for widgets in posts instead of options. You should run migrate first.
 	 */
 	public function enable() {
-		if ( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME ) ) {
+		if ( $this->get_widget_posts()->is_enabled() ) {
 			\WP_CLI::warning( 'Widget Posts already enabled.' );
 		} else {
-			$result = update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
+			$result = $this->get_widget_posts()->enable();
 			if ( $result ) {
 				\WP_CLI::success( 'Widget Posts enabled.' );
 			} else {
@@ -51,10 +51,10 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 * Disable looking for widgets in posts instead of options.
 	 */
 	public function disable() {
-		if ( ! get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME ) ) {
+		if ( ! $this->get_widget_posts()->is_enabled() ) {
 			\WP_CLI::warning( 'Widget Posts already disabled.' );
 		} else {
-			$result = update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, false );
+			$result = $this->get_widget_posts()->disable();
 			if ( $result ) {
 				\WP_CLI::success( 'Widget Posts disabled.' );
 			} else {

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -180,8 +180,13 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 			unset( $assoc_args );
 
 			$widget_posts = $this->get_widget_posts();
-			$data = $widget_posts->get_widget_instance_data( $widget_id );
-			echo json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+			$post = $widget_posts->get_widget_post( $widget_id );
+			if ( ! $post ) {
+				\WP_CLI::warning( "Widget post $widget_id does not exist." );
+			} else {
+				$data = $widget_posts->get_widget_instance_data( $post );
+				echo json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+			}
 		} catch ( \Exception $e ) {
 			\WP_CLI::error( sprintf( '%s: %s', get_class( $e ), $e->getMessage() ) );
 		}

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+/**
+ * Manage widget instances stored in posts.
+ *
+ * @package CustomizeWidgetsPlus
+ */
+class Widget_Posts_CLI_Command extends \WP_CLI_Command {
+
+	/**
+	 * @var Widget_Posts
+	 */
+	public $widget_posts;
+
+	/**
+	 * This gets set by Widget_Posts::__construct()
+	 *
+	 * @var Plugin
+	 */
+	static public $plugin_instance;
+
+	/**
+	 * @return Widget_Posts
+	 */
+	public function get_widget_posts() {
+		if ( ! isset( static::$plugin_instance->widget_posts ) ) {
+			static::$plugin_instance->widget_posts = new Widget_Posts( static::$plugin_instance );
+		}
+		return static::$plugin_instance->widget_posts;
+	}
+
+	/**
+	 * Enable looking for widgets in posts instead of options. You should run migrate first.
+	 */
+	public function enable() {
+		if ( get_option( 'widget_posts_enabled' ) ) {
+			\WP_CLI::warning( 'Widget Posts already enabled.' );
+		} else {
+			$result = update_option( 'widget_posts_enabled', true );
+			if ( $result ) {
+				\WP_CLI::success( 'Widget Posts enabled.' );
+			} else {
+				\WP_CLI::error( 'Failed to enable Widget Posts.' );
+			}
+		}
+	}
+
+	/**
+	 * Disable looking for widgets in posts instead of options.
+	 */
+	public function disable() {
+		if ( ! get_option( 'widget_posts_enabled' ) ) {
+			\WP_CLI::warning( 'Widget Posts already disabled.' );
+		} else {
+			$result = update_option( 'widget_posts_enabled', false );
+			if ( $result ) {
+				\WP_CLI::success( 'Widget Posts disabled.' );
+			} else {
+				\WP_CLI::error( 'Failed to disable Widget Posts.' );
+			}
+		}
+	}
+
+	/**
+	 * Migrate widget instances from options into posts. Posts that already exist for given widget IDs will not be-imported unless --update is supplied.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --update
+	 * : Update any widget instance posts already migrated/imported. This would override any changes made since the last migration.
+	 *
+	 * --dry-run
+	 * : Show what would be migrated.
+	 *
+	 * --verbose
+	 * : Show more info about what is going on.
+	 *
+	 * @param array [$id_bases]
+	 * @param array $options
+	 * @synopsis [<id_bases>...] [--dry-run] [--update] [--verbose]
+	 */
+	public function migrate( $id_bases, $options ) {
+		try {
+			$widget_posts = $this->get_widget_posts();
+
+			$options = array_merge(
+				array(
+					'update' => false,
+					'verbose' => false,
+					'dry-run' => false,
+				),
+				$options
+			);
+			if ( empty( $id_bases ) ) {
+				$id_bases = array_keys( $widget_posts->widget_objs );
+			} else {
+				foreach ( $id_bases as $id_base ) {
+					if ( ! array_key_exists( $id_base, $widget_posts->widget_objs ) ) {
+						\WP_CLI::error( "Unrecognized id_base: $id_base" );
+					}
+				}
+			}
+
+			$updated_count = 0;
+			$skipped_count = 0;
+			$inserted_count = 0;
+			$failed_count = 0;
+
+			add_action( 'widget_posts_import_skip_existing', function ( $context ) use ( $options, &$skipped_count ) {
+				// $context is compact( 'widget_id', 'instance', 'widget_number', 'id_base' )
+				if ( $options['verbose'] ) {
+					\WP_CLI::line( "Skipping already-imported widget $context[widget_id]." );
+				}
+				$skipped_count += 1;
+			} );
+
+			add_action( 'widget_posts_import_success', function ( $context ) use ( $options, &$updated_count, &$inserted_count ) {
+				// $context is compact( 'widget_id', 'post', 'instance', 'widget_number', 'id_base', 'update' )
+				if ( $context['update'] ) {
+					$message = "Updated widget $context[widget_id].";
+					$updated_count += 1;
+				} else {
+					$message = "Inserted widget $context[widget_id].";
+					$inserted_count += 1;
+				}
+				if ( $options['dry-run'] ) {
+					$message .= ' (Dry run.)';
+				}
+				\WP_CLI::success( $message );
+			} );
+
+			add_action( 'widget_posts_import_failure', function ( $context ) use ( &$failed_count ) {
+				// $context is compact( 'widget_id', 'exception', 'instance', 'widget_number', 'id_base', 'update' )
+				/** @var Exception $exception */
+				$exception = $context['exception'];
+				\WP_CLI::warning( "Failed to import $context[widget_id]: " . $exception->getMessage() );
+				$failed_count += 1;
+			} );
+
+			$widget_posts->pre_option_filters_disabled = true;
+			foreach ( $id_bases as $id_base ) {
+				$widget_obj = $widget_posts->widget_objs[ $id_base ];
+				$instances = $widget_obj->get_settings();
+				$widget_posts->import_widget_instances( $id_base, $instances, $options );
+			}
+			$widget_posts->pre_option_filters_disabled = false;
+
+			\WP_CLI::line();
+			\WP_CLI::line( "Skipped: $skipped_count" );
+			\WP_CLI::line( "Updated: $updated_count" );
+			\WP_CLI::line( "Inserted: $inserted_count" );
+			\WP_CLI::line( "Failed: $failed_count" );
+
+		} catch ( \Exception $e ) {
+			\WP_CLI::error( sprintf( '%s: %s', get_class( $e ), $e->getMessage() ) );
+		}
+
+	}
+
+	/**
+	 * Import widget instances from a JSON dump mapping widget IDs (e.g. {"search-123":{"title":"Buscar"} }.
+	 *
+	 *
+	 */
+	public function import() {
+		\WP_CLI::error( 'Not implemented.' );
+	}
+
+	/**
+	 * Show the instance data for the given widget ID in JSON format.
+	 *
+	 * ## OPTIONS
+	 *
+	 * @param array [$args]
+	 * @param array $assoc_args
+	 * @synopsis <widget_id>
+	 */
+	public function show( $args, $assoc_args ) {
+		try {
+			$widget_id = array_shift( $args );
+			unset( $assoc_args );
+
+			$widget_posts = $this->get_widget_posts();
+			$data = $widget_posts->get_widget_instance_data( $widget_id );
+			echo json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n";
+		} catch ( \Exception $e ) {
+			\WP_CLI::error( sprintf( '%s: %s', get_class( $e ), $e->getMessage() ) );
+		}
+	}
+
+}

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -35,10 +35,10 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 * Enable looking for widgets in posts instead of options. You should run migrate first.
 	 */
 	public function enable() {
-		if ( get_option( 'widget_posts_enabled' ) ) {
+		if ( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME ) ) {
 			\WP_CLI::warning( 'Widget Posts already enabled.' );
 		} else {
-			$result = update_option( 'widget_posts_enabled', true );
+			$result = update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
 			if ( $result ) {
 				\WP_CLI::success( 'Widget Posts enabled.' );
 			} else {
@@ -51,10 +51,10 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 * Disable looking for widgets in posts instead of options.
 	 */
 	public function disable() {
-		if ( ! get_option( 'widget_posts_enabled' ) ) {
+		if ( ! get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME ) ) {
 			\WP_CLI::warning( 'Widget Posts already disabled.' );
 		} else {
-			$result = update_option( 'widget_posts_enabled', false );
+			$result = update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, false );
 			if ( $result ) {
 				\WP_CLI::success( 'Widget Posts disabled.' );
 			} else {

--- a/php/class-widget-posts-cli-command.php
+++ b/php/class-widget-posts-cli-command.php
@@ -83,6 +83,9 @@ class Widget_Posts_CLI_Command extends \WP_CLI_Command {
 	 */
 	public function migrate( $id_bases, $options ) {
 		try {
+			if ( ! defined( 'WP_IMPORTING' ) ) {
+				define( 'WP_IMPORTING', true );
+			}
 			$widget_posts = $this->get_widget_posts();
 
 			$options = array_merge(

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -298,18 +298,22 @@ class Widget_Posts {
 	 *
 	 * @see WP_Customize_Widgets::capture_filter_pre_update_option()
 	 *
-	 * @param array $value
-	 * @param array $old_value
+	 * @param Widget_Settings|array $value
+	 * @param Widget_Settings|array $old_value
 	 * @return array
 	 */
 	function filter_pre_update_option_widget_settings( $value, $old_value ) {
+		// Get literal arrays for comparison since two separate instances can never be identical (===)
+		$value_array = ( $value instanceof Widget_Settings ? $value->getArrayCopy() : $value );
+		$old_value_array = ( $old_value instanceof Widget_Settings ? $old_value->getArrayCopy() : $old_value );
+
 		$matches = array();
 		$should_filter = (
 			! $this->pre_option_filters_disabled
 			&&
-			( $value !== $old_value )
+			( $value_array !== $old_value_array )
 			&&
-			( $value instanceof \ArrayIterator )
+			( $value instanceof Widget_Settings )
 			&&
 			preg_match( '/pre_update_option_widget_(.+)/', current_filter(), $matches )
 		);

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -103,6 +103,7 @@ class Widget_Posts {
 			'wp_insert_post_data' => array( $this, 'preserve_content_filtered' ),
 			'delete_post' => array( $this, 'flush_widget_instance_numbers_cache' ),
 			'save_post_' . static::INSTANCE_POST_TYPE => array( $this, 'flush_widget_instance_numbers_cache' ),
+			'export_wp' => array( $this, 'setup_export' ),
 		);
 		foreach ( $hooks as $hook => $callback ) {
 			// Note that add_action() and has_action() is an aliases for add_filter() and has_filter()
@@ -148,6 +149,19 @@ class Widget_Posts {
 		}
 
 		return $r;
+	}
+
+	/**
+	 * When exporting widget instance posts from WordPress, export the post_content_filtered as the post_content.
+	 *
+	 * @action export_wp
+	 */
+	function setup_export() {
+		add_action( 'the_post', function ( $post ) {
+			if ( static::INSTANCE_POST_TYPE === $post->post_type  ) {
+				$post->post_content = $post->post_content_filtered;
+			}
+		} );
 	}
 
 	/**

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -206,7 +206,8 @@ class Widget_Posts {
 	function filter_wp_import_post_data_processed( $postdata ) {
 		if ( static::INSTANCE_POST_TYPE === $postdata['post_type'] ) {
 			$postdata['post_content_filtered'] = $postdata['post_content'];
-			$postdata['post_content'] = '';
+			$instance = Widget_Posts::parse_post_content_filtered( $postdata['post_content'] );
+			$postdata['post_content'] = $postdata['post_content'] = wp_json_encode( $instance, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );;
 		}
 		return $postdata;
 	}

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -180,7 +180,6 @@ class Widget_Posts {
 			add_filter( "pre_option_{$widget_obj->option_name}", array( $this, 'filter_pre_option_widget_settings' ), 20 );
 			add_filter( "pre_update_option_{$widget_obj->option_name}", array( $this, 'filter_pre_update_option_widget_settings' ), 20, 2 );
 		}
-
 	}
 
 	/**
@@ -198,9 +197,9 @@ class Widget_Posts {
 	function filter_pre_option_widget_settings( $pre ) {
 		$matches = array();
 		$should_filter = (
-			null === $pre
+			false === $pre
 			&&
-			$this->is_migrating_widgets_from_options
+			! $this->is_migrating_widgets_from_options
 			&&
 			preg_match( '/pre_option_widget_(.+)/', current_filter(), $matches )
 		);
@@ -230,7 +229,6 @@ class Widget_Posts {
 			}
 		}
 
-		// @todo We probably should instead return $settings->getIterator();
 		return $settings;
 	}
 
@@ -247,11 +245,11 @@ class Widget_Posts {
 	function filter_pre_update_option_widget_settings( $value, $old_value ) {
 		$matches = array();
 		$should_filter = (
-			$this->is_migrating_widgets_from_options
+			! $this->is_migrating_widgets_from_options
 			&&
 			( $value !== $old_value )
 			&&
-			( $value instanceof \ArrayObject )
+			( $value instanceof \ArrayAccess )
 			&&
 			preg_match( '/pre_update_option_widget_(.+)/', current_filter(), $matches )
 		);

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -133,7 +133,7 @@ class Widget_Posts {
 
 		add_filter( 'wp_insert_post_data', array( $this, 'preserve_content_filtered' ), 10, 2 ); // @todo priority 20? Before or after Widget_Instance_Post_Edit::insert_post_name()?
 		add_action( 'delete_post', array( $this, 'flush_widget_instance_numbers_cache' ) );
-		add_action( 'save_post', array( $this, 'flush_widget_instance_numbers_cache' ) );
+		add_action( 'save_post_' . static::INSTANCE_POST_TYPE, array( $this, 'flush_widget_instance_numbers_cache' ) );
 
 		return $r;
 	}
@@ -210,7 +210,7 @@ class Widget_Posts {
 		}
 		$this->pre_option_filters_disabled = true;
 		foreach ( $this->widget_objs as $id_base => $widget_obj ) {
-			$instances = $widget_obj->get_settings();
+			$instances = $widget_obj->get_settings(); // Note that $this->pre_option_filters_disabled must be true so this returns an array, not a Widget_Settings.
 			$this->import_widget_instances( $id_base, $instances, $options );
 		}
 		$this->pre_option_filters_disabled = false;
@@ -616,7 +616,7 @@ class Widget_Posts {
 	 * Flush the widget instance numbers cache when a post is updated or deleted.
 	 *
 	 * @param int $post_id
-	 * @action save_post
+	 * @action save_post_widget_instance
 	 * @action delete_post
 	 */
 	function flush_widget_instance_numbers_cache( $post_id ) {

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -708,18 +708,15 @@ class Widget_Posts {
 			$post_id = $post->ID;
 		}
 		if ( $options['needs_sanitization'] ) {
-			$old_instance = array();
 			if ( $post ) {
-				try {
-					$old_instance = $this->get_widget_instance_data( $post );
-				} catch ( Exception $e ) {
-					$old_instance = array();
-				}
+				$old_instance = $this->get_widget_instance_data( $post );
+			} else {
+				$old_instance = array();
 			}
 			$instance = $this->sanitize_instance( $parsed_widget_id['id_base'], $instance, $old_instance );
 		}
 
-		// Make sure that we have the max stored
+		// Make sure that we have the max stored.
 		$this->plugin->widget_number_incrementing->set_widget_number( $parsed_widget_id['id_base'], $parsed_widget_id['widget_number'] );
 
 		$post_arr = array(

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -61,7 +61,7 @@ class Widget_Posts {
 	function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
 
-		add_option( self::ENABLED_FLAG_OPTION_NAME, false, '', 'yes' );
+		add_option( self::ENABLED_FLAG_OPTION_NAME, 'no', '', 'yes' );
 		add_action( 'widgets_init', array( $this, 'store_widget_objects' ), 90 );
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -76,9 +76,36 @@ class Widget_Posts {
 			} );
 		}
 
-		if ( get_option( self::ENABLED_FLAG_OPTION_NAME ) ) {
+		if ( $this->is_enabled() ) {
 			$this->init();
 		}
+	}
+
+	/**
+	 * Whether the functionality is enabled.
+	 *
+	 * @return bool Enabled.
+	 */
+	function is_enabled() {
+		return 'yes' === get_option( self::ENABLED_FLAG_OPTION_NAME );
+	}
+
+	/**
+	 * Enable the functionality (for the next load).
+	 *
+	 * @return bool Whether it was able to update the enabled state.
+	 */
+	function enable() {
+		return update_option( self::ENABLED_FLAG_OPTION_NAME, 'yes' );
+	}
+
+	/**
+	 * Disable the functionality (for the next load).
+	 *
+	 * @return bool Whether it was able to update the enabled state.
+	 */
+	function disable() {
+		return update_option( self::ENABLED_FLAG_OPTION_NAME, 'no' );
 	}
 
 	/**

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -565,7 +565,7 @@ class Widget_Posts {
 		if ( empty( $post ) ) {
 			$instance = array();
 		} else {
-			$instance = static::parse_post_content_filtered( $post );
+			$instance = static::get_post_content_filtered( $post );
 		}
 		return $instance;
 	}
@@ -589,18 +589,29 @@ class Widget_Posts {
 	 * @param \WP_Post $post
 	 * @return array
 	 */
-	static function parse_post_content_filtered( \WP_Post $post ) {
+	static function get_post_content_filtered( \WP_Post $post ) {
 		if ( static::INSTANCE_POST_TYPE !== $post->post_type ) {
 			return array();
 		}
 		if ( empty( $post->post_content_filtered ) ) {
 			return array();
 		}
-		$decoded_instance = base64_decode( $post->post_content_filtered, true );
+		return static::parse_post_content_filtered( $post->post_content_filtered );
+	}
+
+	/**
+	 * Parse the post_content_filtered from its base64-encodd PHP-serialized string.
+	 *
+	 * @param string $post_content_filtered
+	 *
+	 * @return array
+	 */
+	static function parse_post_content_filtered( $post_content_filtered ) {
+		$decoded_instance = base64_decode( $post_content_filtered, true );
 		if ( false !== $decoded_instance ) {
 			$instance = unserialize( $decoded_instance );
-		} else if ( is_serialized( $post->post_content_filtered, true ) ) {
-			$instance = unserialize( $post->post_content_filtered );
+		} else if ( is_serialized( $post_content_filtered, true ) ) {
+			$instance = unserialize( $post_content_filtered );
 		} else {
 			$instance = array();
 		}

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -650,7 +650,7 @@ class Widget_Posts {
 		$widget_number = $this->plugin->widget_number_incrementing->incr_widget_number( $id_base );
 		$post_arr = array(
 			'post_name' => "$id_base-$widget_number",
-			// @todo 'post_content' => wp_json_encode( $instance ), // for search indexing
+			'post_content' => wp_json_encode( $instance, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ), // For search indexing and post revision UI.
 			'post_content_filtered' => static::encode_post_content_filtered( $instance ),
 			'post_status' => 'publish',
 			'post_type' => static::INSTANCE_POST_TYPE,
@@ -703,7 +703,7 @@ class Widget_Posts {
 		$post_arr = array(
 			'post_title' => ! empty( $instance['title'] ) ? $instance['title'] : '',
 			'post_name' => $widget_id,
-			// @todo 'post_content' => wp_json_encode( $instance ), // for search indexing
+			'post_content' => wp_json_encode( $instance, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ), // For search indexing and post revision UI.
 			'post_content_filtered' => static::encode_post_content_filtered( $instance ),
 			'post_status' => 'publish',
 			'post_type' => static::INSTANCE_POST_TYPE,

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -1,0 +1,561 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+/**
+ * Store widgets in posts as opposed to options.
+ *
+ * This makes non_autoloaded_widget_options obsolete.
+ *
+ * @package CustomizeWidgetsPlus
+ */
+class Widget_Posts {
+
+	const MODULE_SLUG = 'widget_posts';
+
+	const INSTANCE_POST_TYPE = 'widget_instance';
+
+	/**
+	 * @var Plugin
+	 */
+	public $plugin;
+
+	/**
+	 * @var \WP_Customize_Manager
+	 */
+	public $manager;
+
+	/**
+	 * @var \WP_Widget[]
+	 */
+	public $widget_objs;
+
+	/**
+	 * @return array
+	 */
+	static function default_config() {
+		return array();
+	}
+
+	/**
+	 * Return the config entry for the supplied key, or all configs if not supplied.
+	 *
+	 * @param string $key
+	 * @return array|mixed
+	 */
+	function config( $key = null ) {
+		if ( is_null( $key ) ) {
+			return $this->plugin->config[ static::MODULE_SLUG ];
+		} else if ( isset( $this->plugin->config[ static::MODULE_SLUG ][ $key ] ) ) {
+			return $this->plugin->config[ static::MODULE_SLUG ][ $key ];
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @param Plugin $plugin
+	 */
+	function __construct( Plugin $plugin ) {
+		$this->plugin = $plugin;
+
+		add_option( 'widget_posts_migrated', false, '', 'yes' );
+		add_action( 'widgets_init', array( $this, 'store_widget_objects' ), 90 );
+
+		// @todo WP-CLI script for converting widget_options
+		if ( get_option( 'widget_posts_migrated' ) ) {
+			$this->init();
+		}
+	}
+
+	/**
+	 * Add the hooks for the primary functionality.
+	 */
+	function init() {
+		add_action( 'widgets_init', array( $this, 'prepare_widget_data' ), 91 );
+		add_action( 'init', array( $this, 'register_instance_post_type' ) );
+		add_filter( 'wp_insert_post_data', array( $this, 'preserve_content_filtered' ), 10, 2 ); // @todo priority 20? Before or after Widget_Instance_Post_Edit::insert_post_name()?
+		add_action( 'delete_post', array( $this, 'flush_widget_instance_numbers_cache' ) );
+		add_action( 'save_post', array( $this, 'flush_widget_instance_numbers_cache' ) );
+	}
+
+	/**
+	 * Register the widget_instance post type.
+	 *
+	 * @action init
+	 */
+	function register_instance_post_type() {
+
+		$labels = array(
+			'name'               => _x( 'Widget Instances', 'post type general name', 'mandatory-widgets' ),
+			'singular_name'      => _x( 'Widget Instance', 'post type singular name', 'mandatory-widgets' ),
+			'menu_name'          => _x( 'Widget Instances', 'admin menu', 'mandatory-widgets' ),
+			'name_admin_bar'     => _x( 'Widget Instance', 'add new on admin bar', 'mandatory-widgets' ),
+			'add_new'            => _x( 'Add New', 'Widget', 'mandatory-widgets' ),
+			'add_new_item'       => __( 'Add New Widget Instance', 'mandatory-widgets' ),
+			'new_item'           => __( 'New Widget Instance', 'mandatory-widgets' ),
+			'edit_item'          => __( 'Edit Widget Instance', 'mandatory-widgets' ),
+			'view_item'          => __( 'View Widget Instance', 'mandatory-widgets' ),
+			'all_items'          => __( 'All Widget Instances', 'mandatory-widgets' ),
+			'search_items'       => __( 'Search Widget instances', 'mandatory-widgets' ),
+			'not_found'          => __( 'No widget instances found.', 'mandatory-widgets' ),
+			'not_found_in_trash' => __( 'No widget instances found in Trash.', 'mandatory-widgets' ),
+		);
+
+		$args = array(
+			'labels' => $labels,
+			'public' => false,
+			'capability_type' => static::INSTANCE_POST_TYPE,
+			'map_meta_cap' => true,
+			'hierarchical' => false,
+			'delete_with_user' => false,
+			'menu_position' => null,
+			'supports' => array( 'none' ), // @todo 'revisions' when there is a UI.
+		);
+		register_post_type( static::INSTANCE_POST_TYPE, $args );
+	}
+
+	/**
+	 * @see \WP_Widget::get_settings()
+	 *
+	 * @param string $id_base
+	 * @param array $instances
+	 * @throws Exception
+	 */
+	function import_widget_instances( $id_base, array $instances ) {
+		if ( ! array_key_exists( $id_base, $this->widget_objs ) ) {
+			throw new Exception( "Unrecognized $id_base widget ID base." );
+		}
+		unset( $instances['_multiwidget'] );
+		foreach ( $instances as $widget_number => $instance ) {
+			$widget_number = absint( $widget_number );
+			if ( ! $widget_number ) {
+				continue;
+			}
+
+			$widget_id = "$id_base-$widget_number";
+			$this->update_widget( $widget_id, $instance );
+			$this->plugin->stop_the_insanity();
+		}
+	}
+
+	public $is_migrating_widgets_from_options = false;
+
+	/**
+	 *
+	 */
+	function migrate_widgets_from_options() {
+		if ( ! $this->plugin->is_running_unit_tests() && ! defined( 'WP_IMPORTING' ) ) {
+			define( 'WP_IMPORTING', true );
+		}
+		$this->is_migrating_widgets_from_options = true;
+		foreach ( $this->widget_objs as $id_base => $widget_obj ) {
+			$instances = $widget_obj->get_settings();
+			$this->import_widget_instances( $id_base, $instances );
+		}
+		$this->is_migrating_widgets_from_options = false;
+	}
+
+	/**
+	 *
+	 * @action widgets_init, 90
+	 */
+	function store_widget_objects() {
+
+		foreach ( $this->plugin->widget_factory->widgets as $widget_obj ) {
+			/** @var \WP_Widget $widget_obj */
+			if ( "widget_{$widget_obj->id_base}" !== $widget_obj->option_name ) {
+				continue;
+			}
+			$this->widget_objs[ $widget_obj->id_base ] = $widget_obj;
+		}
+	}
+
+	/**
+	 *
+	 * @action widgets_init, 91
+	 */
+	function prepare_widget_data() {
+		foreach ( $this->widget_objs as $id_base => $widget_obj ) {
+			add_filter( "pre_option_{$widget_obj->option_name}", array( $this, 'filter_pre_option_widget_settings' ), 20 );
+			add_filter( "pre_update_option_{$widget_obj->option_name}", array( $this, 'filter_pre_update_option_widget_settings' ), 20, 2 );
+		}
+
+	}
+
+	/**
+	 * Return the Widget_Settings ArrayObject on the pre_option filter for the widget option.
+	 *
+	 * @param null|array $pre
+	 *
+	 * Note that this is after 10 so it is compatible with WP_Customize_Widgets::capture_filter_pre_get_option()
+	 *
+	 * @see WP_Customize_Widgets::capture_filter_pre_get_option()
+	 * @filter pre_option_{WP_Widget::$option_name}, 20
+	 *
+	 * @return Widget_Settings|mixed
+	 */
+	function filter_pre_option_widget_settings( $pre ) {
+		$matches = array();
+		$should_filter = (
+			null === $pre
+			&&
+			$this->is_migrating_widgets_from_options
+			&&
+			preg_match( '/pre_option_widget_(.+)/', current_filter(), $matches )
+		);
+		if ( ! $should_filter ) {
+			return $pre;
+		}
+		$id_base = $matches[1];
+		$instances = $this->get_widget_instance_numbers( $id_base ); // A.K.A. shallow widget instances.
+
+		if ( has_filter( "option_widget_{$id_base}" ) ) {
+			$filtered_instances = array_fill_keys( array_keys( $instances ), array() );
+			$filtered_instances = apply_filters( "option_widget_{$id_base}", $filtered_instances ); // Warning: filters may expect widget instances to be present.
+			$filtered_instances = array_filter( $filtered_instances, function ( $value ) {
+				return ! empty( $value );
+			} );
+			$instances = array_merge( $instances, $filtered_instances );
+		}
+
+		$settings = new Widget_Settings( $instances );
+
+		if ( has_filter( "option_widget_{$id_base}" ) ) {
+			$filtered_settings = apply_filters( "option_widget_{$id_base}", $settings );
+
+			// Detect when a filter blew away our nice ArrayObject.
+			if ( $filtered_settings !== $settings ) {
+				$settings = new Widget_Settings( $filtered_settings );
+			}
+		}
+
+		// @todo We probably should instead return $settings->getIterator();
+		return $settings;
+	}
+
+	/**
+	 * Note that this that this is designed to not conflict with Widget Customizer,
+	 * and the capturing of update_option() calls.
+	 *
+	 * @see WP_Customize_Widgets::capture_filter_pre_update_option()
+	 *
+	 * @param array $value
+	 * @param array $old_value
+	 * @return array
+	 */
+	function filter_pre_update_option_widget_settings( $value, $old_value ) {
+		$matches = array();
+		$should_filter = (
+			$this->is_migrating_widgets_from_options
+			&&
+			( $value !== $old_value )
+			&&
+			( $value instanceof \ArrayObject )
+			&&
+			preg_match( '/pre_update_option_widget_(.+)/', current_filter(), $matches )
+		);
+		if ( ! $should_filter ) {
+			return $value;
+		}
+		$id_base = $matches[1];
+
+		$instances = $value->getArrayCopy();
+		foreach ( $instances as $widget_number => $instance ) {
+			$widget_number = absint( $widget_number );
+			if ( ! $widget_number || ! is_array( $instance ) ) { // Note that non-arrays are most likely widget_instance post IDs.
+				continue;
+			}
+			$widget_id = "$id_base-$widget_number";
+
+			$this->update_widget( $widget_id, $instance );
+		}
+
+		// Return the old value so that update_option() short circuits.
+		return $old_value;
+	}
+
+	/**
+	 * Get all numbers for widget instances for the given $id_base mapped to the widget_instance post IDs.
+	 *
+	 * @param string $id_base
+	 *
+	 * @return int[] Mapping of widget instance numbers to post IDs.
+	 */
+	function get_widget_instance_numbers( $id_base ) {
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+		$numbers = wp_cache_get( $id_base, 'widget_instance_numbers' );
+		if ( false === $numbers ) {
+			$post_type = static::INSTANCE_POST_TYPE;
+			$widget_id_hyphen_strpos = strlen( $id_base ) + 1; // Start at the last hyphen in the widget ID
+
+			/*
+			 * Get all widget numbers from widget_instance posts, where the post_name
+			 * fields consist of $id_base-$widget_number, such as "text-123".
+			 * Note that there is no LIMIT on this query, but it is reasoned that
+			 * this is not a risk since the amount of data returned is very small (an array of digits),
+			 * and we're interacting with post_type and post_name fields, which are both
+			 * indexed in MySQL. Note also that the pattern in the post_name LIKE condition does
+			 * not start with % so it will not do a full table scan.
+			 */
+			$results = $wpdb->get_results( $wpdb->prepare(
+				"
+					SELECT ID as post_id, SUBSTRING( post_name, %d + 1 ) as widget_number
+					FROM $wpdb->posts
+					WHERE
+						post_type = %s
+						AND
+						post_name LIKE %s
+						AND
+						SUBSTRING( post_name, %d + 1 ) REGEXP '^[0-9]+$'
+				",
+				array(
+					$widget_id_hyphen_strpos,
+					$post_type,
+					$wpdb->esc_like( $id_base . '-' ) . '%',
+					$widget_id_hyphen_strpos,
+				)
+			) ); // WPCS: db call ok.
+
+			$numbers = array();
+			foreach ( $results as $result ) {
+				$numbers[ intval( $result->widget_number ) ] = intval( $result->post_id );
+			}
+
+			wp_cache_set( $id_base, $numbers, 'widget_instance_numbers' );
+		}
+		return $numbers;
+	}
+
+	/**
+	 * Get the widget instance post associated witha given widget ID.
+	 *
+	 * @param string $widget_id
+	 * @return \WP_Post|null
+	 */
+	function get_widget_post( $widget_id ) {
+		// @todo it may be better to just do a SQL query here: $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_name = %s", array( static::INSTANCE_POST_TYPE, $widget_id ) ) )
+
+		$post_stati = array_merge(
+			array( 'any' ),
+			array_values( get_post_stati( array( 'exclude_from_search' => true ) ) ) // otherwise, we could get duplicates
+		);
+
+		// Force is_single and is_page to be false, so that draft and scheduled posts can be queried by name
+		$married = function ( $q ) {
+			$q->is_single = false;
+		};
+		add_action( 'pre_get_posts', $married );
+
+		$query = new \WP_Query( array(
+			'post_status' => $post_stati,
+			'posts_per_page' => 1,
+			'post_type' => static::INSTANCE_POST_TYPE,
+			'name' => $widget_id,
+		) );
+
+		remove_action( 'pre_get_posts', $married );
+
+		$post = array_shift( $query->posts );
+		return $post;
+	}
+
+	/**
+	 * Get the instance data associated with a widget post.
+	 *
+	 * @param int|\WP_Post|string $post Widget ID, post, or widget_ID string.
+	 * @return array
+	 */
+	function get_widget_instance_data( $post ) {
+		if ( is_string( $post ) ) {
+			$post = $this->get_widget_post( $post );
+		} else {
+			$post = get_post( $post );
+		}
+
+		if ( empty( $post ) ) {
+			$this->plugin->trigger_warning( 'Invalid widget post' );
+			$instance = array();
+		} else if ( static::INSTANCE_POST_TYPE !== $post->post_type ) {
+			$this->plugin->trigger_warning( "Invalid widget post type: $post->post_type" );
+			$instance = array();
+		} else if ( empty( $post->post_content_filtered ) ) {
+			$instance = array(); // uninitialized widget post
+		} else if ( ! is_serialized( $post->post_content_filtered, true ) ) {
+			$this->plugin->trigger_warning( "Expected post $post->ID to have valid serialized data, but got: $post->post_content_filtered" );
+			$instance = array();
+		} else {
+			$instance = unserialize( $post->post_content_filtered );
+			if ( ! is_array( $instance ) ) {
+				$this->plugin->trigger_warning( "Expected post $post->ID to have an array, but got: $post->post_content_filtered" );
+				$instance = array();
+			}
+		}
+		return $instance;
+	}
+
+	/**
+	 * Sanitize a widget's instance array by passing it through the widget's update callback.
+	 *
+	 * @see \WP_Widget::update()
+	 *
+	 * @param string $id_base
+	 * @param array $new_instance
+	 * @param array $old_instance
+	 * @return array
+	 *
+	 * @throws Exception
+	 */
+	public function sanitize_instance( $id_base, $new_instance, $old_instance = array() ) {
+		if ( ! array_key_exists( $id_base, $this->widget_objs ) ) {
+			throw new Exception( "Unrecognized widget id_base: $id_base" );
+		}
+		if ( ! is_array( $new_instance ) ) {
+			throw new Exception( 'new_instance data must be an array' );
+		}
+		if ( ! is_array( $old_instance ) ) {
+			throw new Exception( 'old_instance data must be an array' );
+		}
+		$widget_obj = $this->widget_objs[ $id_base ];
+		// @codingStandardsIgnoreStart
+		$instance = @ $widget_obj->update( $new_instance, $old_instance ); // silencing errors because we can get undefined index notices
+		// @codingStandardsIgnoreEnd
+		return $instance;
+	}
+
+	/**
+	 * Create a new widget instance.
+	 *
+	 * @param string $id_base
+	 * @param array $instance
+	 * @return \WP_Post
+	 *
+	 * @throws Exception
+	 */
+	function insert_widget( $id_base, $instance = array() ) {
+		if ( ! array_key_exists( $id_base, $this->widget_objs ) ) {
+			throw new Exception( "Unrecognized widget id_base: $id_base" );
+		}
+
+		$instance = $this->sanitize_instance( $id_base, $instance );
+		$widget_number = $this->plugin->widget_number_incrementing->incr_widget_number( $id_base );
+		$post_arr = array(
+			'post_name' => "$id_base-$widget_number",
+			// @todo 'post_content' => wp_json_encode( $instance ), // for search indexing
+			'post_content_filtered' => serialize( $instance ),
+			'post_status' => 'publish',
+			'post_type' => static::INSTANCE_POST_TYPE,
+		);
+		$r = wp_insert_post( $post_arr, true );
+		if ( is_wp_error( $r ) ) {
+			throw new Exception( sprintf(
+				'Failed to insert/update widget instance "%s": %s',
+				$post_arr['post_name'],
+				$r->get_error_code()
+			) );
+		}
+		$post = get_post( $r );
+		return $post;
+	}
+
+	/**
+	 * Update an existing widget.
+	 *
+	 * @param string $widget_id
+	 * @param array $instance
+	 * @throws Exception
+	 * @return \WP_Post
+	 */
+	function update_widget( $widget_id, $instance = array() ) {
+		$parsed_widget_id = $this->plugin->parse_widget_id( $widget_id );
+		if ( empty( $parsed_widget_id ) ) {
+			throw new Exception( "Invalid widget_id: $widget_id" );
+		}
+
+		$post_id = null;
+		$old_instance = array();
+		$post = $this->get_widget_post( $widget_id );
+		if ( $post ) {
+			$post_id = $post->ID;
+			try {
+				$old_instance = $this->get_widget_instance_data( $post );
+			} catch ( Exception $e ) {
+				$old_instance = array();
+			}
+		}
+		$instance = $this->sanitize_instance( $parsed_widget_id['id_base'], $instance, $old_instance );
+
+		// Make sure that we have the max stored
+		$this->plugin->widget_number_incrementing->set_widget_number( $parsed_widget_id['id_base'], $parsed_widget_id['widget_number'] );
+
+		$post_arr = array(
+			'post_title' => ! empty( $instance['title'] ) ? $instance['title'] : '',
+			'post_name' => $widget_id,
+			// @todo 'post_content' => wp_json_encode( $instance ), // for search indexing
+			'post_content_filtered' => serialize( $instance ),
+			'post_status' => 'publish',
+			'post_type' => static::INSTANCE_POST_TYPE,
+		);
+		if ( $post_id ) {
+			$post_arr['ID'] = $post_id;
+		}
+
+		$r = wp_insert_post( $post_arr, true );
+		if ( is_wp_error( $r ) ) {
+			throw new Exception( sprintf(
+				'Failed to insert/update widget instance "%s": %s',
+				$post_arr['post_name'],
+				$r->get_error_code()
+			) );
+		}
+		$post = get_post( (int) $r );
+		return $post;
+	}
+
+	/**
+	 * Make sure that wp_update_post() doesn't clear out our content.
+	 *
+	 * @param array $data    An array of slashed post data.
+	 * @param array $postarr An array of sanitized, but otherwise unmodified post data.
+	 * @return array
+	 *
+	 * @filter wp_insert_post_data
+	 */
+	function preserve_content_filtered( $data, $postarr ) {
+		$should_preserve = (
+			! empty( $postarr['ID'] )
+			&&
+			static::INSTANCE_POST_TYPE === $postarr['post_type']
+			&&
+			empty( $data['post_content_filtered'] )
+		);
+		if ( $should_preserve ) {
+			$previous_content_filtered = get_post( $postarr['ID'] )->post_content_filtered;
+			$previous_content_filtered = wp_slash( $previous_content_filtered ); // >:-(
+			$data['post_content_filtered'] = $previous_content_filtered;
+		}
+		return $data;
+	}
+
+	/**
+	 * Flush the widget instance numbers cache when a post is updated or deleted.
+	 *
+	 * @param int $post_id
+	 * @action save_post
+	 * @action delete_post
+	 */
+	function flush_widget_instance_numbers_cache( $post_id ) {
+		$post = get_post( $post_id );
+		if ( static::INSTANCE_POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		$parsed_widget_id = $this->plugin->parse_widget_id( $post->post_name );
+		if ( empty( $parsed_widget_id['id_base'] ) ) {
+			return;
+		}
+		wp_cache_delete( $parsed_widget_id['id_base'], 'widget_instance_numbers' );
+	}
+
+
+}

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -704,10 +704,12 @@ class Widget_Posts {
 
 		$post_id = null;
 		$post = $this->get_widget_post( $widget_id );
+		if ( $post ) {
+			$post_id = $post->ID;
+		}
 		if ( $options['needs_sanitization'] ) {
 			$old_instance = array();
 			if ( $post ) {
-				$post_id = $post->ID;
 				try {
 					$old_instance = $this->get_widget_instance_data( $post );
 				} catch ( Exception $e ) {

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -104,6 +104,7 @@ class Widget_Posts {
 			'delete_post' => array( $this, 'flush_widget_instance_numbers_cache' ),
 			'save_post_' . static::INSTANCE_POST_TYPE => array( $this, 'flush_widget_instance_numbers_cache' ),
 			'export_wp' => array( $this, 'setup_export' ),
+			'wp_import_post_data_processed' => array( $this, 'filter_wp_import_post_data_processed' ),
 		);
 		foreach ( $hooks as $hook => $callback ) {
 			// Note that add_action() and has_action() is an aliases for add_filter() and has_filter()
@@ -154,6 +155,8 @@ class Widget_Posts {
 	/**
 	 * When exporting widget instance posts from WordPress, export the post_content_filtered as the post_content.
 	 *
+	 * @see Widget_Posts::filter_wp_import_post_data_processed()
+	 *
 	 * @action export_wp
 	 */
 	function setup_export() {
@@ -162,6 +165,23 @@ class Widget_Posts {
 				$post->post_content = $post->post_content_filtered;
 			}
 		} );
+	}
+
+	/**
+	 * Restore post_content into post_content_filtered when importing via WordPress Importer plugin.
+	 *
+	 * @see Widget_Posts::setup_export()
+	 * @filter wp_import_post_data_processed
+	 *
+	 * @param array $postdata
+	 * @return array
+	 */
+	function filter_wp_import_post_data_processed( $postdata ) {
+		if ( static::INSTANCE_POST_TYPE === $postdata['post_type'] ) {
+			$postdata['post_content_filtered'] = $postdata['post_content'];
+			$postdata['post_content'] = '';
+		}
+		return $postdata;
 	}
 
 	/**

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -85,7 +85,7 @@ class Widget_Settings extends \ArrayIterator {
 	 * @param mixed      $value The array item value.
 	 */
 	public function offsetSet( $key, $value ) {
-		if ( '_multiwidget' === $key ) {
+		if ( '_multiwidget' === $key || '__i__' === $key ) {
 			return;
 		}
 		$key = filter_var( $key, FILTER_VALIDATE_INT );
@@ -107,15 +107,13 @@ class Widget_Settings extends \ArrayIterator {
 	 * @param int|string $key Array key.
 	 */
 	public function offsetUnset( $key ) {
-		if ( '_multiwidget' === $key ) {
+		if ( '_multiwidget' === $key || '__i__' === $key ) {
 			return;
 		}
 		parent::offsetUnset( $key );
 	}
 
 	/**
-	 * Get the
-	 *
 	 * @return array
 	 */
 	public function current() {

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -30,6 +30,13 @@ namespace CustomizeWidgetsPlus;
 class Widget_Settings extends \ArrayIterator {
 
 	/**
+	 * Keep track of all widget instances that were unset, as they will be deleted.
+	 *
+	 * @var int[] $unset_widget_numbers
+	 */
+	public $unset_widget_numbers = array();
+
+	/**
 	 * @param array $array
 	 * @throws Exception
 	 */
@@ -125,6 +132,11 @@ class Widget_Settings extends \ArrayIterator {
 		if ( '_multiwidget' === $key || '__i__' === $key ) {
 			return;
 		}
+		$key = filter_var( $key, FILTER_VALIDATE_INT );
+		if ( $key < 2 ) {
+			return;
+		}
+		$this->unset_widget_numbers[] = $key;
 		parent::offsetUnset( $key );
 	}
 

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -82,14 +82,7 @@ class Widget_Settings extends \ArrayIterator {
 		if ( is_int( $value ) ) {
 			// Fetch the widget post_content_filtered and store it in the array.
 			$post = get_post( $value );
-			if ( empty( $post ) ) {
-				$value = array();
-			} else {
-				$value = unserialize( $post->post_content_filtered );
-				if ( ! is_array( $value ) ) {
-					$value = array();
-				}
-			}
+			$value = Widget_Posts::parse_post_content_filtered( $post );
 			$this->offsetSet( $key, $value );
 		}
 		return $value;

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -82,7 +82,7 @@ class Widget_Settings extends \ArrayIterator {
 		if ( is_int( $value ) ) {
 			// Fetch the widget post_content_filtered and store it in the array.
 			$post = get_post( $value );
-			$value = Widget_Posts::parse_post_content_filtered( $post );
+			$value = Widget_Posts::get_post_content_filtered( $post );
 			$this->offsetSet( $key, $value );
 		}
 		return $value;

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Widget Settings.
+ *
+ * @package CustomizeWidgetsPlus
+ */
+
+namespace CustomizeWidgetsPlus;
+
+// @todo WP_Widget::get_settings() that grabs all instance _numbers_
+// @todo WP-CLI command for migrating widget options to widget settings posts.
+// @todo Filters should not be added if the options haven't been migrated into posts.
+
+/**
+ * Efficient emulation of the widget settings array as returned by \WP_Widget::get_settings().
+ *
+ * Mapping of widget numbers to the widget_instance post ID if shallow, or to
+ * the widget instance array if the value has been retrieved via offsetGet.
+ *
+ * @see \WP_Widget::get_settings()
+ * @see \WP_Widget::save_settings()
+ *
+ * The following PHP functions are compatible with ArrayObject:
+ *  - array_key_exists
+ *
+ *
+ * \WP_Widget::update_callback(): $all_instances = $this->get_settings();
+ * \WP_Widget::update_callback(): $this->save_settings($all_instances);
+ * \WP_Widget::form_callback(): $all_instances = $this->get_settings();
+ * \WP_Widget::_register(): if ( is_array($settings) ) {
+ * \WP_Widget::_register(): foreach ( array_keys($settings) as $number ) {
+ * \WP_Widget::display_callback(): $instance = $this->get_settings();
+ *
+ * @package CustomizeWidgetsPlus
+ */
+class Widget_Settings extends \ArrayIterator {
+
+	/**
+	 *
+	 * \WP_Widget::update_callback(): $old_instance = isset($all_instances[$number]) ? $all_instances[$number] : array();
+	 * \WP_Widget::display_callback(): if ( array_key_exists( $this->number, $instance ) ) {
+	 * \WP_Widget::get_settings(): if ( !empty($settings) && !array_key_exists('_multiwidget', $settings) ) {
+	 *
+	 * @param int|string $key Array key.
+	 * @return bool
+	 */
+	public function offsetExists( $key ) {
+		if ( '_multiwidget' === $key ) {
+			return true;
+		}
+		return parent::offsetExists( $key );
+	}
+
+	/**
+	 * \WP_Widget::update_callback(): $old_instance = isset($all_instances[$number]) ? $all_instances[$number] : array();
+	 * \WP_Widget::display_callback(): $instance = $instance[$this->number];
+	 * \WP_Widget::form_callback(): $instance = $all_instances[ $widget_args['number'] ];
+	 *
+	 * @param int|string $key Array key.
+	 * @return array|int|null
+	 */
+	public function offsetGet( $key ) {
+		if ( '_multiwidget' === $key ) {
+			return 1;
+		}
+		if ( ! $this->offsetExists( $key ) ) {
+			return null;
+		}
+		$value = parent::offsetGet( $key );
+		if ( is_int( $value ) ) {
+			// Fetch the widget post_content_filtered and store it in the array.
+			$post = get_post( $value );
+			$value = unserialize( $post->post_content_filtered );
+			$this->offsetSet( $key, $value );
+		}
+		assert( is_array( $value ) );
+		return $value;
+	}
+
+	/**
+	 * \WP_Widget::update_callback(): $all_instances[$number] = $instance;
+	 * \WP_Widget::save_settings(): $settings['_multiwidget'] = 1;
+	 *
+	 * @param int|string $key Array key.
+	 * @param mixed      $value The array item value.
+	 */
+	public function offsetSet( $key, $value ) {
+		if ( '_multiwidget' === $key ) {
+			return;
+		}
+		$key = filter_var( $key, FILTER_VALIDATE_INT );
+		if ( ! is_int( $key ) ) {
+			// @todo _doing_it_wrong()?
+			return;
+		}
+		if ( ! is_array( $value ) ) {
+			// @todo _doing_it_wrong()?
+			return;
+		}
+		parent::offsetSet( $key, $value );
+	}
+
+	/**
+	 * \WP_Widget::update_callback(): unset($all_instances[$number]);
+	 * \WP_Widget::get_settings(): unset($settings['_multiwidget'], $settings['__i__']);
+	 *
+	 * @param int|string $key Array key.
+	 */
+	public function offsetUnset( $key ) {
+		if ( '_multiwidget' === $key ) {
+			return;
+		}
+		parent::offsetUnset( $key );
+	}
+
+	/**
+	 * Get the
+	 *
+	 * @return array
+	 */
+	public function current() {
+		return $this->offsetGet( $this->key() );
+	}
+
+	/**
+	 * Serialize the settings into an array.
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+		return serialize( $this->getArrayCopy() );
+	}
+
+}

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -7,9 +7,7 @@
 
 namespace CustomizeWidgetsPlus;
 
-// @todo WP_Widget::get_settings() that grabs all instance _numbers_
 // @todo WP-CLI command for migrating widget options to widget settings posts.
-// @todo Filters should not be added if the options haven't been migrated into posts.
 
 /**
  * Efficient emulation of the widget settings array as returned by \WP_Widget::get_settings().
@@ -19,10 +17,6 @@ namespace CustomizeWidgetsPlus;
  *
  * @see \WP_Widget::get_settings()
  * @see \WP_Widget::save_settings()
- *
- * The following PHP functions are compatible with ArrayObject:
- *  - array_key_exists
- *
  *
  * \WP_Widget::update_callback(): $all_instances = $this->get_settings();
  * \WP_Widget::update_callback(): $this->save_settings($all_instances);

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -30,7 +30,18 @@ namespace CustomizeWidgetsPlus;
 class Widget_Settings extends \ArrayIterator {
 
 	/**
-	 *
+	 * @param array $array
+	 * @throws Exception
+	 */
+	function __construct( $array ) {
+		// Widget numbers start at 2.
+		unset( $array[0] );
+		unset( $array[1] );
+
+		parent::__construct( $array );
+	}
+
+	/**
 	 * \WP_Widget::update_callback(): $old_instance = isset($all_instances[$number]) ? $all_instances[$number] : array();
 	 * \WP_Widget::display_callback(): if ( array_key_exists( $this->number, $instance ) ) {
 	 * \WP_Widget::get_settings(): if ( !empty($settings) && !array_key_exists('_multiwidget', $settings) ) {
@@ -84,6 +95,10 @@ class Widget_Settings extends \ArrayIterator {
 		}
 		$key = filter_var( $key, FILTER_VALIDATE_INT );
 		if ( ! is_int( $key ) ) {
+			// @todo _doing_it_wrong()?
+			return;
+		}
+		if ( $key < 2 ) {
 			// @todo _doing_it_wrong()?
 			return;
 		}

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -75,10 +75,16 @@ class Widget_Settings extends \ArrayIterator {
 		if ( is_int( $value ) ) {
 			// Fetch the widget post_content_filtered and store it in the array.
 			$post = get_post( $value );
-			$value = unserialize( $post->post_content_filtered );
+			if ( empty( $post ) ) {
+				$value = array();
+			} else {
+				$value = unserialize( $post->post_content_filtered );
+				if ( ! is_array( $value ) ) {
+					$value = array();
+				}
+			}
 			$this->offsetSet( $key, $value );
 		}
-		assert( is_array( $value ) );
 		return $value;
 	}
 

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -25,9 +25,9 @@ class Test_Widget_Posts extends Base_Test_Case {
 	 * @see Widget_Posts::__construct()
 	 */
 	function test_construct_unmigrated() {
-		$this->assertNull( get_option( 'widget_posts_migrated', null ) );
+		$this->assertNull( get_option( 'widget_posts_enabled', null ) );
 		$instance = new Widget_Posts( $this->plugin );
-		$this->assertFalse( get_option( 'widget_posts_migrated', null ) );
+		$this->assertFalse( get_option( 'widget_posts_enabled', null ) );
 		wp_widgets_init();
 		$this->assertNotEmpty( $instance->widget_objs );
 		$this->assertFalse( has_action( 'widgets_init', array( $instance, 'prepare_widget_data' ) ) );
@@ -37,7 +37,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 	 * @see Widget_Posts::__construct()
 	 */
 	function test_construct_migrated() {
-		update_option( 'widget_posts_migrated', true );
+		update_option( 'widget_posts_enabled', true );
 		$instance = new Widget_Posts( $this->plugin );
 		$this->assertEquals( 90, has_action( 'widgets_init', array( $instance, 'store_widget_objects' ) ) );
 	}

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -27,7 +27,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 	function test_construct_unmigrated() {
 		$this->assertNull( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, null ) );
 		$instance = new Widget_Posts( $this->plugin );
-		$this->assertFalse( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, null ) );
+		$this->assertEquals( 'no', get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, null ) );
 		wp_widgets_init();
 		$this->assertNotEmpty( $instance->widget_objs );
 		$this->assertFalse( has_action( 'widgets_init', array( $instance, 'prepare_widget_data' ) ) );
@@ -37,7 +37,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 	 * @see Widget_Posts::__construct()
 	 */
 	function test_construct_migrated() {
-		update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
+		update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, 'yes' );
 		$instance = new Widget_Posts( $this->plugin );
 		$this->assertEquals( 90, has_action( 'widgets_init', array( $instance, 'store_widget_objects' ) ) );
 	}

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -96,7 +96,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
 			$this->assertEquals( "$id_base-$widget_number", $post->post_name );
 
-			$this->assertEquals( $original_instances[ $widget_number ], unserialize( $post->post_content_filtered ) );
+			$this->assertEquals( $original_instances[ $widget_number ], Widget_Posts::parse_post_content_filtered( $post ) );
 		}
 
 		// Before any Widget_Settings::offsetGet() gets called, try iterating

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -96,7 +96,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
 			$this->assertEquals( "$id_base-$widget_number", $post->post_name );
 
-			$this->assertEquals( $original_instances[ $widget_number ], Widget_Posts::parse_post_content_filtered( $post ) );
+			$this->assertEquals( $original_instances[ $widget_number ], Widget_Posts::get_post_content_filtered( $post ) );
 		}
 
 		// Before any Widget_Settings::offsetGet() gets called, try iterating

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -25,9 +25,9 @@ class Test_Widget_Posts extends Base_Test_Case {
 	 * @see Widget_Posts::__construct()
 	 */
 	function test_construct_unmigrated() {
-		$this->assertNull( get_option( 'widget_posts_enabled', null ) );
+		$this->assertNull( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, null ) );
 		$instance = new Widget_Posts( $this->plugin );
-		$this->assertFalse( get_option( 'widget_posts_enabled', null ) );
+		$this->assertFalse( get_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, null ) );
 		wp_widgets_init();
 		$this->assertNotEmpty( $instance->widget_objs );
 		$this->assertFalse( has_action( 'widgets_init', array( $instance, 'prepare_widget_data' ) ) );
@@ -37,7 +37,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 	 * @see Widget_Posts::__construct()
 	 */
 	function test_construct_migrated() {
-		update_option( 'widget_posts_enabled', true );
+		update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
 		$instance = new Widget_Posts( $this->plugin );
 		$this->assertEquals( 90, has_action( 'widgets_init', array( $instance, 'store_widget_objects' ) ) );
 	}
@@ -112,6 +112,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 			$this->assertEquals( $original_instance, $settings[ $widget_number ] );
 		}
 
+		$this->assertEquals( 0, did_action( 'update_option_widget_meta' ), 'Expected update_option( "widget_meta" ) to short-circuit.' );
 	}
 
 }

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+class Test_Widget_Posts extends Base_Test_Case {
+
+	/**
+	 * @var \WP_Customize_Manager
+	 */
+	public $wp_customize_manager;
+
+	function setUp() {
+		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+		parent::setUp();
+
+		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );
+	}
+
+	function init_customizer() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->wp_customize_manager = new \WP_Customize_Manager();
+	}
+
+	/**
+	 * @see Widget_Posts::__construct()
+	 */
+	function test_construct_unmigrated() {
+		$this->assertNull( get_option( 'widget_posts_migrated', null ) );
+		$instance = new Widget_Posts( $this->plugin );
+		$this->assertFalse( get_option( 'widget_posts_migrated', null ) );
+		wp_widgets_init();
+		$this->assertNotEmpty( $instance->widget_objs );
+		$this->assertFalse( has_action( 'widgets_init', array( $instance, 'prepare_widget_data' ) ) );
+	}
+
+	/**
+	 * @see Widget_Posts::__construct()
+	 */
+	function test_construct_migrated() {
+		update_option( 'widget_posts_migrated', true );
+		$instance = new Widget_Posts( $this->plugin );
+		$this->assertEquals( 90, has_action( 'widgets_init', array( $instance, 'store_widget_objects' ) ) );
+	}
+
+	/**
+	 * @see Widget_Posts::init()
+	 */
+	function test_init() {
+		$instance = new Widget_Posts( $this->plugin );
+		$instance->init();
+		$this->assertEquals( 90, has_action( 'widgets_init', array( $instance, 'store_widget_objects' ) ) );
+		$this->assertEquals( 91, has_action( 'widgets_init', array( $instance, 'prepare_widget_data' ) ) );
+		$this->assertEquals( 10, has_action( 'init', array( $instance, 'register_instance_post_type' ) ) );
+		$this->assertEquals( 10, has_filter( 'wp_insert_post_data', array( $instance, 'preserve_content_filtered' ) ) );
+		$this->assertEquals( 10, has_action( 'delete_post', array( $instance, 'flush_widget_instance_numbers_cache' ) ) );
+		$this->assertEquals( 10, has_action( 'save_post', array( $instance, 'flush_widget_instance_numbers_cache' ) ) );
+	}
+
+	/**
+	 * @see Widget_Posts::register_instance_post_type()
+	 */
+	function test_register_instance_post_type() {
+		$instance = new Widget_Posts( $this->plugin );
+		$instance->register_instance_post_type();
+		$this->assertNotEmpty( get_post_type_object( Widget_Posts::INSTANCE_POST_TYPE ) );
+	}
+
+	/**
+	 * @see Widget_Posts::migrate_widgets_from_options()
+	 */
+	function test_migrate_widgets_from_options() {
+		$id_base = 'meta';
+		$original_instances = get_option( "widget_{$id_base}" );
+		unset( $original_instances['_multiwidget'] );
+
+		$instance = new Widget_Posts( $this->plugin );
+		$instance->init();
+		wp_widgets_init();
+
+		$this->assertEmpty( $instance->get_widget_instance_numbers( $id_base ) );
+		$instance->migrate_widgets_from_options();
+		$shallow_instances = $instance->get_widget_instance_numbers( $id_base );
+		$this->assertNotEmpty( $shallow_instances );
+
+		$this->assertEqualSets( array_keys( $original_instances ), array_keys( $shallow_instances ) );
+
+		foreach ( $shallow_instances as $widget_number => $post_id ) {
+			$this->assertInternalType( 'int', $widget_number );
+			$this->assertInternalType( 'int', $post_id );
+
+			$post = get_post( $post_id );
+			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
+			$this->assertEquals( "$id_base-$widget_number", $post->post_name );
+
+			$this->assertEquals( $original_instances[ $widget_number ], unserialize( $post->post_content_filtered ) );
+		}
+
+		// Before any Widget_Settings::offsetGet() gets called, try iterating
+		$settings = new Widget_Settings( $shallow_instances );
+		foreach ( $settings as $widget_number => $hydrated_instance ) {
+			$this->assertEquals( $original_instances[ $widget_number ], $hydrated_instance );
+		}
+
+		// Now make sure that offsetGet() also does the right thing.
+		$settings = new Widget_Settings( $shallow_instances );
+		foreach ( $original_instances as $widget_number => $original_instance ) {
+			$this->assertArrayHasKey( $widget_number, $settings );
+			$this->assertEquals( $original_instance, $settings[ $widget_number ] );
+		}
+
+	}
+
+}

--- a/tests/test-class-widget-settings.php
+++ b/tests/test-class-widget-settings.php
@@ -108,7 +108,7 @@ class Test_Widget_Settings extends Base_Test_Case {
 		foreach ( $settings as $widget_number => $instance ) {
 			$this->assertInternalType( 'array', $instance );
 			$this->assertContains( 'widget_posts', $instance['title'] );
-			$this->assertEquals( $instance, unserialize( get_post( $shallow_settings[ $widget_number ] )->post_content_filtered ) );
+			$this->assertEquals( $instance, Widget_Posts::parse_post_content_filtered( get_post( $shallow_settings[ $widget_number ] ) ) );
 		}
 	}
 }

--- a/tests/test-class-widget-settings.php
+++ b/tests/test-class-widget-settings.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+class Test_Widget_Settings extends Base_Test_Case {
+
+	function setUp() {
+		parent::setUp();
+		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );
+		$this->plugin->widget_posts = new Widget_Posts( $this->plugin );
+		wp_widgets_init();
+	}
+
+	/**
+	 * @param string $id_base
+	 * @param int $count
+	 *
+	 * @return Widget_Settings
+	 */
+	function create_widget_settings( $id_base, $count = 3 ) {
+		$instances = array();
+		for ( $i = 2; $i < 2 + $count; $i += 1 ) {
+			$post = $this->plugin->widget_posts->insert_widget( $id_base, array(
+				'title' => "Hello world for widget_posts $i",
+			) );
+			$instances[ $i ] = $post->ID;
+		}
+		$settings = new Widget_Settings( $instances );
+		return $settings;
+	}
+
+	/**
+	 * @see Widget_Settings::offsetGet()
+	 */
+	function test_offset_get() {
+		$settings = $this->create_widget_settings( 'meta', 3 );
+		$shallow_settings = $settings->getArrayCopy();
+		foreach ( $shallow_settings as $widget_number => $post_id ) {
+			$this->assertInternalType( 'int', $widget_number );
+			$this->assertInternalType( 'int', $post_id );
+		}
+
+		$this->assertEquals( 1, $settings['_multiwidget'] );
+		$this->assertNull( $settings[100] );
+		$instance = $settings[2];
+		$this->assertInternalType( 'array', $instance );
+		$this->assertContains( 'widget_posts', $instance['title'] );
+
+		foreach ( array_keys( $shallow_settings ) as $widget_number ) {
+			$instance = $settings[ $widget_number ];
+			$this->assertInternalType( 'array', $instance );
+			$this->assertContains( 'widget_posts', $instance['title'] );
+		}
+	}
+
+	/**
+	 * @see Widget_Settings::offsetSet()
+	 */
+	function test_offset_set() {
+		$settings = $this->create_widget_settings( 'meta', 3 );
+		$before = $settings->getArrayCopy();
+		$settings['_multiwidget'] = 1;
+		$this->assertEquals( $before, $settings->getArrayCopy() );
+
+		$before = $settings->getArrayCopy();
+		$settings['sdasd'] = array( 'title' => 'as' );
+		$this->assertEquals( $before, $settings->getArrayCopy() );
+
+		$before = $settings->getArrayCopy();
+		$settings[4] = 'asdasd';
+		$this->assertEquals( $before, $settings->getArrayCopy() );
+
+		$before = $settings->getArrayCopy();
+		$settings[50] = array( 'title' => 'Set' );
+		$this->assertNotEquals( $before, $settings->getArrayCopy() );
+	}
+
+	/**
+	 * @see Widget_Settings::offsetExists()
+	 */
+	function test_exists() {
+		$settings = $this->create_widget_settings( 'meta', 3 );
+		$this->assertFalse( isset( $settings[1000] ) );
+		$this->assertTrue( isset( $settings['_multiwidget'] ) );
+		$this->assertTrue( isset( $settings[2] ) );
+		$this->assertFalse( isset( $settings[100] ) );
+	}
+
+	/**
+	 * @see Widget_Settings::offsetUnset()
+	 */
+	function test_offset_unset() {
+		$settings = $this->create_widget_settings( 'meta', 3 );
+		$this->assertTrue( isset( $settings['_multiwidget'] ) );
+		$before = $settings->getArrayCopy();
+		unset( $settings['_multiwidget'] ); // A no-op.
+		$this->assertTrue( isset( $settings['_multiwidget'] ) );
+		$this->assertEquals( $before, $settings->getArrayCopy() );
+	}
+
+	/**
+	 * @see Widget_Settings::current()
+	 */
+	function test_current() {
+		$settings = $this->create_widget_settings( 'meta', 3 );
+		$shallow_settings = $settings->getArrayCopy();
+
+		foreach ( $settings as $widget_number => $instance ) {
+			$this->assertInternalType( 'array', $instance );
+			$this->assertContains( 'widget_posts', $instance['title'] );
+			$this->assertEquals( $instance, unserialize( get_post( $shallow_settings[ $widget_number ] )->post_content_filtered ) );
+		}
+	}
+}

--- a/tests/test-class-widget-settings.php
+++ b/tests/test-class-widget-settings.php
@@ -108,7 +108,7 @@ class Test_Widget_Settings extends Base_Test_Case {
 		foreach ( $settings as $widget_number => $instance ) {
 			$this->assertInternalType( 'array', $instance );
 			$this->assertContains( 'widget_posts', $instance['title'] );
-			$this->assertEquals( $instance, Widget_Posts::parse_post_content_filtered( get_post( $shallow_settings[ $widget_number ] ) ) );
+			$this->assertEquals( $instance, Widget_Posts::get_post_content_filtered( get_post( $shallow_settings[ $widget_number ] ) ) );
 		}
 	}
 }

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -38,12 +38,16 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 
 		$this->plugin->widget_posts->migrate_widgets_from_options();
 		$this->plugin->widget_posts->init();
+		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.
+		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 	}
 
 	function test_register_settings() {
 		parent::test_register_settings();
 		$this->assertInstanceOf( __NAMESPACE__ . '\\WP_Customize_Widget_Setting', $this->manager->get_setting( 'widget_categories[2]' ) );
 		$this->assertEquals( 'widget', $this->manager->get_setting( 'widget_categories[2]' )->type );
+
+		$this->assertInstanceOf( __NAMESPACE__ . '\\Widget_Settings', get_option( 'widget_categories' ) );
 	}
 
 }

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -36,7 +36,7 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 			add_action( $widgets_init_hook, $callable, $priority );
 		}
 
-		update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
+		$this->plugin->widget_posts->enable();
 		$this->plugin->widget_posts->migrate_widgets_from_options();
 		$this->plugin->widget_posts->init();
 		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( empty( $_tests_dir ) ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+require_once $_tests_dir . '/tests/customize/widgets.php';
+
+class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_Widgets {
+
+	/**
+	 * @var Widget_Posts
+	 */
+	public $plugin;
+
+	function setUp() {
+		global $wp_widget_factory;
+
+		parent::setUp();
+		$this->plugin = new Plugin();
+		$this->plugin->widget_factory = $wp_widget_factory;
+		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );
+		$this->plugin->widget_posts = new Widget_Posts( $this->plugin );
+
+		$widgets_init_hook = 'widgets_init';
+		$callable = array( $wp_widget_factory, '_register_widgets' );
+		$priority = has_action( $widgets_init_hook, $callable );
+		if ( false !== $priority ) {
+			remove_action( $widgets_init_hook, $callable, $priority );
+		}
+		wp_widgets_init();
+		if ( false !== $priority ) {
+			add_action( $widgets_init_hook, $callable, $priority );
+		}
+
+		$this->plugin->widget_posts->migrate_widgets_from_options();
+		$this->plugin->widget_posts->init();
+	}
+
+}

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -2,11 +2,10 @@
 
 namespace CustomizeWidgetsPlus;
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( empty( $_tests_dir ) ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+if ( ! getenv( 'WP_TESTS_DIR' ) ) {
+	throw new \Exception( 'WP_TESTS_DIR env var is empty; expected to point to {develop.svn.wordpress.org}/tests/phpunit/' );
 }
-require_once $_tests_dir . '/tests/customize/widgets.php';
+require_once getenv( 'WP_TESTS_DIR' ) . '/tests/customize/widgets.php';
 
 class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_Widgets {
 

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -23,6 +23,7 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 		$this->plugin->widget_factory = $wp_widget_factory;
 		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );
 		$this->plugin->widget_posts = new Widget_Posts( $this->plugin );
+		$this->plugin->efficient_multidimensional_setting_sanitizing = new Efficient_Multidimensional_Setting_Sanitizing( $this->plugin, $this->manager );
 
 		$widgets_init_hook = 'widgets_init';
 		$callable = array( $wp_widget_factory, '_register_widgets' );
@@ -37,6 +38,12 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 
 		$this->plugin->widget_posts->migrate_widgets_from_options();
 		$this->plugin->widget_posts->init();
+	}
+
+	function test_register_settings() {
+		parent::test_register_settings();
+		$this->assertInstanceOf( __NAMESPACE__ . '\\WP_Customize_Widget_Setting', $this->manager->get_setting( 'widget_categories[2]' ) );
+		$this->assertEquals( 'widget', $this->manager->get_setting( 'widget_categories[2]' )->type );
 	}
 
 }

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -36,6 +36,7 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 			add_action( $widgets_init_hook, $callable, $priority );
 		}
 
+		update_option( Widget_Posts::ENABLED_FLAG_OPTION_NAME, true );
 		$this->plugin->widget_posts->migrate_widgets_from_options();
 		$this->plugin->widget_posts->init();
 		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.
@@ -43,6 +44,7 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 	}
 
 	function test_register_settings() {
+		wp_widgets_init();
 		parent::test_register_settings();
 		$this->assertInstanceOf( __NAMESPACE__ . '\\WP_Customize_Widget_Setting', $this->manager->get_setting( 'widget_categories[2]' ) );
 		$this->assertEquals( 'widget', $this->manager->get_setting( 'widget_categories[2]' )->type );

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -37,6 +37,8 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 
 		$this->plugin->widget_posts->migrate_widgets_from_options();
 		$this->plugin->widget_posts->init();
+		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.
+		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 	}
 
 }

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -41,9 +41,13 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 	}
 
+	/**
+	 * @see \Tests_Widgets::test_wp_widget_get_settings()
+	 * @link https://github.com/xwp/wordpress-develop/pull/85
+	 */
 	function test_wp_widget_get_settings() {
 		if ( ! method_exists( '\Tests_Widgets', 'test_wp_widget_get_settings' ) ) {
-			$this->markTestSkipped( 'Test requires Core patch to be applied.' );
+			$this->markTestSkipped( 'Test requires Core patch from https://github.com/xwp/wordpress-develop/pull/85 to be applied.' );
 			return;
 		}
 
@@ -55,15 +59,41 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 		parent::test_wp_widget_get_settings();
 	}
 
+	/**
+	 * @see \Tests_Widgets::test_wp_widget_save_settings()
+	 * @link https://github.com/xwp/wordpress-develop/pull/85
+	 */
 	function test_wp_widget_save_settings() {
 		if ( ! method_exists( '\Tests_Widgets', 'test_wp_widget_save_settings' ) ) {
-			$this->markTestSkipped( 'Test requires Core patch to be applied.' );
+			$this->markTestSkipped( 'Test requires Core patch from https://github.com/xwp/wordpress-develop/pull/85 to be applied.' );
 			return;
 		}
 
 		parent::test_wp_widget_save_settings();
 
 		$this->assertEquals( 0, did_action( 'update_option_widget_search' ), 'Expected update_option( "widget_meta" ) to short-circuit.' );
+	}
+
+	/**
+	 * @see \Tests_Widgets::test_wp_widget_save_settings_delete()
+	 * @link https://github.com/xwp/wordpress-develop/pull/85
+	 */
+	function test_wp_widget_save_settings_delete() {
+		if ( ! method_exists( '\Tests_Widgets', 'test_wp_widget_save_settings_delete' ) ) {
+			$this->markTestSkipped( 'Test requires Core patch from https://github.com/xwp/wordpress-develop/pull/85 to be applied.' );
+			return;
+		}
+
+		$deleted_widget_id = null;
+		add_action( 'delete_post', function ( $post_id ) use ( &$deleted_widget_id ) {
+			$post = get_post( $post_id );
+			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
+			$deleted_widget_id = $post->post_name;
+		}, 10, 2 );
+
+		parent::test_wp_widget_save_settings_delete();
+
+		$this->assertEquals( 'search-2', $deleted_widget_id );
 	}
 
 }

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CustomizeWidgetsPlus;
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( empty( $_tests_dir ) ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+require_once $_tests_dir . '/tests/widgets.php';
+
+class Test_Core_With_Widget_Posts extends \Tests_Widgets {
+
+	/**
+	 * @var Widget_Posts
+	 */
+	public $plugin;
+
+	function setUp() {
+		global $wp_widget_factory;
+
+		parent::setUp();
+		$this->plugin = new Plugin();
+		$this->plugin->widget_factory = $wp_widget_factory;
+		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );
+		$this->plugin->widget_posts = new Widget_Posts( $this->plugin );
+
+		$widgets_init_hook = 'widgets_init';
+		$callable = array( $wp_widget_factory, '_register_widgets' );
+		$priority = has_action( $widgets_init_hook, $callable );
+		if ( false !== $priority ) {
+			remove_action( $widgets_init_hook, $callable, $priority );
+		}
+		wp_widgets_init();
+		if ( false !== $priority ) {
+			add_action( $widgets_init_hook, $callable, $priority );
+		}
+
+		$this->plugin->widget_posts->migrate_widgets_from_options();
+		$this->plugin->widget_posts->init();
+	}
+
+}

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -2,16 +2,15 @@
 
 namespace CustomizeWidgetsPlus;
 
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( empty( $_tests_dir ) ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+if ( ! getenv( 'WP_TESTS_DIR' ) ) {
+	throw new \Exception( 'WP_TESTS_DIR env var is empty; expected to point to {develop.svn.wordpress.org}/tests/phpunit/' );
 }
-require_once $_tests_dir . '/tests/widgets.php';
+require_once getenv( 'WP_TESTS_DIR' ) . '/tests/widgets.php';
 
 class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 
 	/**
-	 * @var Widget_Posts
+	 * @var Plugin
 	 */
 	public $plugin;
 
@@ -19,6 +18,7 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 		global $wp_widget_factory;
 
 		parent::setUp();
+
 		$this->plugin = new Plugin();
 		$this->plugin->widget_factory = $wp_widget_factory;
 		$this->plugin->widget_number_incrementing = new Widget_Number_Incrementing( $this->plugin );

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -41,4 +41,29 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 	}
 
+	function test_wp_widget_get_settings() {
+		if ( ! method_exists( '\Tests_Widgets', 'test_wp_widget_get_settings' ) ) {
+			$this->markTestSkipped( 'Test requires Core patch to be applied.' );
+			return;
+		}
+
+		add_filter( 'pre_option_widget_search', function ( $value ) {
+			$this->assertNotFalse( $value, 'Expected widget_search option to have been short-circuited.' );
+			return $value;
+		}, 1000 );
+
+		parent::test_wp_widget_get_settings();
+	}
+
+	function test_wp_widget_save_settings() {
+		if ( ! method_exists( '\Tests_Widgets', 'test_wp_widget_save_settings' ) ) {
+			$this->markTestSkipped( 'Test requires Core patch to be applied.' );
+			return;
+		}
+
+		parent::test_wp_widget_save_settings();
+
+		$this->assertEquals( 0, did_action( 'update_option_widget_search' ), 'Expected update_option( "widget_meta" ) to short-circuit.' );
+	}
+
 }


### PR DESCRIPTION
Depends on Core patch in https://github.com/xwp/wordpress-develop/pull/85 which is [now committed](https://core.trac.wordpress.org/changeset/32602)!
- [x] Make sure that WXR import/export work as expected.
- [x] Diagnose object cache issue when toggling enabled state.
- [x] Fix [Core unit test error](https://github.com/xwp/wp-customize-widgets-plus/pull/12#discussion-diff-30951432).
- [x] Ensure that widget instance data is preserved and correct during `wp widget-posts migrate`.
- [x] Store widget instance as pretty-printed JSON in `post_content` for sake of revision history and searching.
- [x] Implement the `wp widget-posts import` command which takes data from JSON input as opposed to `wp widget-posts migrate` which takes it from options.
## Nice to haves
- [ ] ~~Add object-caching for widget ID => post ID lookups.~~ (See https://github.com/xwp/wp-customize-widgets-plus/issues/19)
- [ ] ~~Stop loading inactive widget instances into the Customizer, as this adds needless page size.~~ (See https://github.com/xwp/wp-customize-widgets-plus/issues/17)
- [ ] ~~Consider doing batch `widget_instance` post retrieval via a `post__in`. This should be done when the Customizer is going to get all registered widget settings, and it should be done for all widget IDs in `wp_get_sidebar_widgets()`. This is less of a concern when an external object cache is used, since in that case each widget will only get a DB call when first loading the page (e.g. `SELECT * FROM wp_posts WHERE ID = 1999 LIMIT 1`).~~ (See https://github.com/xwp/wp-customize-widgets-plus/issues/20)
