### PR TITLE
Prevent wp_convert_widget_settings() from being erronously called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ node_js:
 env:
     - WP_VERSION=trunk WP_MULTISITE=1
 
+branches:
+    only:
+        - master
+
 before_script:
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -317,10 +317,9 @@ class Widget_Posts {
 		$this->widget_objs = array();
 		foreach ( $this->plugin->widget_factory->widgets as $widget_obj ) {
 			/** @var \WP_Widget $widget_obj */
-			if ( "widget_{$widget_obj->id_base}" !== $widget_obj->option_name ) {
-				continue;
+			if ( $this->plugin->is_normal_multi_widget( $widget_obj ) ) {
+				$this->widget_objs[ $widget_obj->id_base ] = $widget_obj;
 			}
-			$this->widget_objs[ $widget_obj->id_base ] = $widget_obj;
 		}
 	}
 

--- a/php/class-wp-customize-widget-setting.php
+++ b/php/class-wp-customize-widget-setting.php
@@ -144,7 +144,6 @@ class WP_Customize_Widget_Setting extends \WP_Customize_Setting {
 		if ( ! isset( $this->_previewed_blog_id ) ) {
 			$this->_previewed_blog_id = get_current_blog_id();
 		}
-		$sanitizing = $this->efficient_multidimensional_setting_sanitizing;
 		$value = $this->post_value();
 		$is_null_because_previewing_new_widget = (
 			is_null( $value )
@@ -171,14 +170,16 @@ class WP_Customize_Widget_Setting extends \WP_Customize_Setting {
 	 * @return void
 	 */
 	protected function update( $value ) {
-		// @todo Better $this->efficient_multidimensional_setting_sanitizing->widget_objs[ $this->widget_id_base ]->get_settings()
+		$sanitizing = $this->efficient_multidimensional_setting_sanitizing;
+
+		// @todo Maybe more elegant to do $sanitizing->widget_objs[ $this->widget_id_base ]->get_settings() or $sanitizing->current_widget_type_values[ $this->widget_id_base ]
 		$option_name = "widget_{$this->widget_id_base}";
 		$option_value = get_option( $option_name, array() );
 		$option_value[ $this->widget_number ] = $value;
+		$option_value['_multiwidget'] = 1; // Ensure this is set so that wp_convert_widget_settings() won't be called in WP_Widget::get_settings().
 		update_option( $option_name, $option_value );
 
 		if ( ! $this->is_previewed ) {
-			$sanitizing = $this->efficient_multidimensional_setting_sanitizing;
 			$sanitizing->current_widget_type_values[ $this->widget_id_base ][ $this->widget_number ] = $value;
 		}
 	}

--- a/tests/test-class-efficient-multidimensional-setting-sanitizing.php
+++ b/tests/test-class-efficient-multidimensional-setting-sanitizing.php
@@ -31,6 +31,54 @@ class Test_Efficient_Multidimensional_Setting_Sanitizing extends Base_Test_Case 
 	}
 
 	/**
+	 * @see Efficient_Multidimensional_Setting_Sanitizing::capture_widget_instance_data()
+	 * @see Efficient_Multidimensional_Setting_Sanitizing::filter_pre_option_widget_settings()
+	 * @see Efficient_Multidimensional_Setting_Sanitizing::disable_filtering_pre_option_widget_settings()
+	 * @see Efficient_Multidimensional_Setting_Sanitizing::enable_filtering_pre_option_widget_settings()
+	 */
+	function test_capture_widget_instance_data() {
+		$is_widget_posts_enabled = (
+			$this->plugin->is_module_active( 'widget_posts' )
+			&&
+			$this->plugin->widget_posts->is_enabled()
+		);
+		$this->assertFalse( $is_widget_posts_enabled );
+
+		$this->init_customizer();
+		$module = new Efficient_Multidimensional_Setting_Sanitizing( $this->plugin, $this->wp_customize_manager );
+		$this->assertEmpty( $module->current_widget_type_values );
+		wp_widgets_init();
+		$this->assertNotEmpty( $module->current_widget_type_values );
+
+		foreach ( $module->current_widget_type_values as $id_base => $instances ) {
+			$this->assertArrayHasKey( $id_base, $module->widget_objs );
+			$widget_obj = $module->widget_objs[ $id_base ];
+			$this->assertInternalType( 'array', $instances );
+			$this->assertArrayHasKey( '_multiwidget', $instances );
+
+			$this->assertEquals( true, has_filter( "pre_option_widget_{$id_base}" ) );
+			$this->assertEquals( $instances, get_option( "widget_{$id_base}" ) );
+
+			unset( $instances['_multiwidget'] );
+			$settings = $widget_obj->get_settings();
+			$this->assertEquals( $instances, $settings );
+
+			$instances[100] = array( 'text' => 'Hello World' );
+			$module->current_widget_type_values[ $id_base ] = $instances;
+			$settings = $widget_obj->get_settings();
+			$this->assertArrayHasKey( 100, $settings );
+			$this->assertEquals( $instances[100], $settings[100] );
+
+			$module->disable_filtering_pre_option_widget_settings();
+			$settings = $widget_obj->get_settings();
+			$this->assertArrayNotHasKey( 100, $settings );
+
+			$module->enable_filtering_pre_option_widget_settings();
+			$this->assertArrayHasKey( 100, $widget_obj->get_settings() );
+		}
+	}
+
+	/**
 	 * @see Efficient_Multidimensional_Setting_Sanitizing::filter_dynamic_setting_class()
 	 */
 	function test_filter_dynamic_setting_class() {


### PR DESCRIPTION
The `Efficient_Multidimensional_Setting_Sanitizing` functionality was storing a widget settings
array which lacked `_multiwidget=1` and so when this value was supplied to the `pre_option_widget_{id_base}` when `WP_Widget::get_settings()` was called, it would end up calling `wp_convert_widget_settings()` and destroying the instance data.

This only applied when Widget Posts was disabled because the Widget_Settings ArrayIterator always has `_multiwidget=1`.

The problem was introduced in https://github.com/xwp/wp-customize-widgets-plus/commit/439b1e0ff26f67eb435c04b2b813a1d6b4590c66 where we switched from getting settings via `get_option()` to getting them via `WP_Widget::get_settings()`.
