### PR TITLE
Sync with clone, update for 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,27 @@ language:
 
 php:
     - 5.4
-    - 5.5
+    - 7.0
 
 node_js:
     - 0.10
 
 env:
     - WP_VERSION=trunk WP_MULTISITE=1
+    - WP_VERSION=trunk WP_MULTISITE=0
 
 branches:
     only:
         - master
 
-before_script:
+install:
     - export DEV_LIB_PATH=dev-lib
     - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
-    - source $DEV_LIB_PATH/travis.before_script.sh
+    - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
+    - source $DEV_LIB_PATH/travis.install.sh
 
 script:
-    - $DEV_LIB_PATH/travis.script.sh
+    - source $DEV_LIB_PATH/travis.script.sh
 
 after_script:
-    - $DEV_LIB_PATH/travis.after_script.sh
+    - source $DEV_LIB_PATH/travis.after_script.sh

--- a/php/class-deferred-customize-widgets.php
+++ b/php/class-deferred-customize-widgets.php
@@ -49,7 +49,7 @@ class Deferred_Customize_Widgets {
 	function config( $key = null ) {
 		if ( is_null( $key ) ) {
 			return $this->plugin->config[ static::MODULE_SLUG ];
-		} else if ( isset( $this->plugin->config[ static::MODULE_SLUG ][ $key ] ) ) {
+		} elseif ( isset( $this->plugin->config[ static::MODULE_SLUG ][ $key ] ) ) {
 			return $this->plugin->config[ static::MODULE_SLUG ][ $key ];
 		} else {
 			return null;

--- a/php/class-deferred-customize-widgets.php
+++ b/php/class-deferred-customize-widgets.php
@@ -220,7 +220,7 @@ class Deferred_Customize_Widgets {
 		echo "})( _wpCustomizeSettings.controls );\n";
 
 		// Re-handle widget/area control autofocus since they were removed when checked before.
-		if ( isset( $_GET['autofocus']['control'] ) ) {
+		if ( isset( $_GET['autofocus']['control'] ) ) { // input var okay; sanitization ok
 			$autofocus_control_id = wp_unslash( $_GET['autofocus']['control'] ); // input var okay; sanitization ok
 			if ( isset( $this->customize_controls[ $autofocus_control_id ] ) ) {
 				printf( "_wpCustomizeSettings.autofocus.control = %s;\n", wp_json_encode( $autofocus_control_id ) );

--- a/php/class-https-resource-proxy.php
+++ b/php/class-https-resource-proxy.php
@@ -76,7 +76,7 @@ class HTTPS_Resource_Proxy {
 	function config( $key = null ) {
 		if ( is_null( $key ) ) {
 			return $this->plugin->config[ self::MODULE_SLUG ];
-		} else if ( isset( $this->plugin->config[ self::MODULE_SLUG ][ $key ] ) ) {
+		} elseif ( isset( $this->plugin->config[ self::MODULE_SLUG ][ $key ] ) ) {
 			return $this->plugin->config[ self::MODULE_SLUG ][ $key ];
 		} else {
 			return null;
@@ -448,7 +448,7 @@ class HTTPS_Resource_Proxy {
 
 			if ( ! empty( $r['headers']['expires'] ) ) {
 				$cache_ttl = strtotime( $r['headers']['expires'] ) - time();
-			} else if ( ! empty( $r['headers']['cache-control'] ) && preg_match( '/max-age=(\d+)/', $r['headers']['cache-control'], $matches ) ) {
+			} elseif ( ! empty( $r['headers']['cache-control'] ) && preg_match( '/max-age=(\d+)/', $r['headers']['cache-control'], $matches ) ) {
 				$cache_ttl = intval( $matches[1] );
 			} else {
 				$cache_ttl = -1;

--- a/php/class-non-autoloaded-widget-options.php
+++ b/php/class-non-autoloaded-widget-options.php
@@ -66,7 +66,7 @@ class Non_Autoloaded_Widget_Options {
 			 * @var \WP_Widget $widget_obj
 			 */
 
-			$is_already_autoloaded = in_array( $widget_obj->option_name, $autoloaded_option_names );
+			$is_already_autoloaded = in_array( $widget_obj->option_name, $autoloaded_option_names, true );
 
 			if ( $is_already_autoloaded ) {
 				// Add to list of options that we need to unautoload
@@ -81,7 +81,9 @@ class Non_Autoloaded_Widget_Options {
 		if ( ! empty( $pending_unautoload_option_names ) ) {
 			$sql_in = join( ',', array_fill( 0, count( $pending_unautoload_option_names ), '%s' ) );
 			$sql = "UPDATE $wpdb->options SET autoload = 'no' WHERE option_name IN ( $sql_in )";
-			$wpdb->query( $wpdb->prepare( $sql, $pending_unautoload_option_names ) ); // db call okay; cache okay
+			// @codingStandardsIgnoreStart
+			$wpdb->query( $wpdb->prepare( $sql, $pending_unautoload_option_names ) );
+			// @codingStandardsIgnoreStop
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 	}

--- a/php/class-optimized-widget-registration.php
+++ b/php/class-optimized-widget-registration.php
@@ -210,7 +210,7 @@ class Optimized_Widget_Registration {
 			foreach ( $sidebar_widget_ids as $i => $widget_id ) {
 				$setting_id = $this->manager->widgets->get_setting_id( $widget_id );
 				$should_register = (
-					in_array( $widget_id, $register_widget_ids )
+					in_array( $widget_id, $register_widget_ids, true )
 					&&
 					isset( $wp_registered_widgets[ $widget_id ] )
 					&&

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -134,7 +134,6 @@ class Plugin extends Plugin_Base {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
 		if ( $this->is_running_unit_tests() ) {
-			$this->disable_widgets_init();
 			$this->config['active_modules'] = array_fill_keys( array_keys( $this->config['active_modules'] ), false );
 		}
 
@@ -264,9 +263,6 @@ class Plugin extends Plugin_Base {
 	function disable_widgets_factory() {
 		$widgets_init_hook = 'widgets_init';
 		$callable = array( $this->widget_factory, '_register_widgets' );
-		if ( did_action( $widgets_init_hook ) ) {
-			trigger_error( 'widgets_init has already been called', E_USER_WARNING );
-		}
 		$priority = has_action( $widgets_init_hook, $callable );
 		if ( false !== $priority ) {
 			remove_action( $widgets_init_hook, $callable, $priority );

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -462,9 +462,9 @@ class Plugin extends Plugin_Base {
 		$unit = empty( $matches[2] ) ? 'B' : $matches[2];
 		if ( 'K' === $unit ) {
 			$value *= 1024;
-		} else if ( 'M' === $unit ) {
+		} elseif ( 'M' === $unit ) {
 			$value *= pow( 1024, 2 );
-		} else if ( 'G' === $unit ) {
+		} elseif ( 'G' === $unit ) {
 			$value *= pow( 1024, 3 );
 		}
 		return $value;

--- a/php/class-widget-number-incrementing.php
+++ b/php/class-widget-number-incrementing.php
@@ -76,10 +76,14 @@ class Widget_Number_Incrementing {
 	 *
 	 * @param $id_base
 	 * @see \next_widget_id_number()
+	 * @throws Exception
 	 *
 	 * @return int
 	 */
 	function get_max_existing_widget_number( $id_base ) {
+		if ( empty( $this->widget_objs[ $id_base ] ) ) {
+			throw new Exception( "No WP_Widget instance captured for $id_base" );
+		}
 		$widget_obj = $this->widget_objs[ $id_base ];
 		// @todo There should be a pre_existing_widget_numbers, pre_max_existing_widget_number filter, or pre_existing_widget_ids to short circuit the expensive WP_Widget::get_settings()
 

--- a/php/class-widget-posts.php
+++ b/php/class-widget-posts.php
@@ -87,7 +87,7 @@ class Widget_Posts {
 	function config( $key = null ) {
 		if ( is_null( $key ) ) {
 			return $this->plugin->config[ static::MODULE_SLUG ];
-		} else if ( isset( $this->plugin->config[ static::MODULE_SLUG ][ $key ] ) ) {
+		} elseif ( isset( $this->plugin->config[ static::MODULE_SLUG ][ $key ] ) ) {
 			return $this->plugin->config[ static::MODULE_SLUG ][ $key ];
 		} else {
 			return null;
@@ -406,7 +406,7 @@ class Widget_Posts {
 		) ) . ')';
 
 		// Widget ID.
-		if ( preg_match_all( '#(\s|^)' . $id_bases_pattern .  '-\d+(\s|$)#', $s, $matches ) ) {
+		if ( preg_match_all( '#(\s|^)' . $id_bases_pattern . '-\d+(\s|$)#', $s, $matches ) ) {
 			$widget_ids = $matches[0];
 			$sql_in = array_fill( 0, count( $widget_ids ), '%s' );
 			$sql_in = implode( ', ', $sql_in );
@@ -975,9 +975,9 @@ class Widget_Posts {
 		if ( false === $pre ) {
 			$instances = $this->get_widget_instance_numbers( $id_base ); // A.K.A. shallow widget instances.
 			$settings = new Widget_Settings( $instances );
-		} else if ( is_array( $pre ) ) {
+		} elseif ( is_array( $pre ) ) {
 			$settings = new Widget_Settings( $pre );
-		} else if ( $pre instanceof Widget_Settings ) {
+		} elseif ( $pre instanceof Widget_Settings ) {
 			$settings = $pre;
 		} else {
 			return $pre;

--- a/php/class-widget-settings.php
+++ b/php/class-widget-settings.php
@@ -78,9 +78,9 @@ class Widget_Settings extends \ArrayIterator {
 		}
 		$value = parent::offsetGet( $key );
 		if ( is_int( $value ) ) {
-			// Fetch the widget post_content_filtered and store it in the array.
+			// Fetch the widget and store it in the array.
 			$post = get_post( $value );
-			$value = Widget_Posts::get_post_content_filtered( $post );
+			$value = Widget_Posts::get_post_content( $post );
 			$this->offsetSet( $key, $value );
 		}
 		return $value;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
 		<const name="WP_TEST_VIP_QUICKSTART_ACTIVATED_PLUGINS" value="jetpack/jetpack.php,media-explorer/media-explorer.php,writing-helper/writing-helper.php,mrss/mrss.php,wordpress-importer/wordpress-importer.php,keyring/keyring.php,polldaddy/polldaddy.php" />
 		<const name="WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING" value="1" />
 		<const name="WP_TEST_ACTIVATED_PLUGINS" value="" /> <!-- this list is used if not on VIP Quickstart -->
-		<const name="WP_TESTS_MULTISITE" value="1" />
 	</php>
 	<testsuites>
 		<testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,37 @@
+<phpunit
+	bootstrap="dev-lib/phpunit-plugin-bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TEST_VIP_QUICKSTART_ACTIVATED_PLUGINS" value="jetpack/jetpack.php,media-explorer/media-explorer.php,writing-helper/writing-helper.php,mrss/mrss.php,wordpress-importer/wordpress-importer.php,keyring/keyring.php,polldaddy/polldaddy.php" />
+		<const name="WPCOM_VIP_DISABLE_REMOTE_REQUEST_ERROR_REPORTING" value="1" />
+		<const name="WP_TEST_ACTIVATED_PLUGINS" value="" /> <!-- this list is used if not on VIP Quickstart -->
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">tests/</directory>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<include>
+			<group>customize-widgets-plus</group>
+		</include>
+	</groups>
+
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<directory suffix=".php">./</directory>
+			<exclude>
+				<directory suffix=".php">./dev-lib</directory>
+				<directory suffix=".php">./node_modules</directory>
+				<directory suffix=".php">./tests</directory>
+				<directory suffix=".php">./vendor</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,1 +1,0 @@
-dev-lib/phpunit-plugin.xml

--- a/tests/test-class-non-autoloaded-widget-options.php
+++ b/tests/test-class-non-autoloaded-widget-options.php
@@ -34,6 +34,7 @@ class Test_Non_Autoloaded_Widget_Options extends Base_Test_Case {
 
 		$registered_option_names = wp_list_pluck( $this->plugin->get_registered_widget_objects(), 'option_name' );
 		$sql_option_names_in = join( ',', array_fill( 0, count( $registered_option_names ), '%s' ) );
+		// @codingStandardsIgnoreStart
 		$unautoloaded_widget_option_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->options WHERE autoload = 'no' AND option_name IN ( $sql_option_names_in )", $registered_option_names ) ); // db call okay; cache okay
 		$this->assertEquals( 0, $unautoloaded_widget_option_count );
 
@@ -45,6 +46,7 @@ class Test_Non_Autoloaded_Widget_Options extends Base_Test_Case {
 
 		$unautoloaded_widget_option_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->options WHERE autoload = 'no' AND option_name IN ( $sql_option_names_in )", $registered_option_names ) ); // db call okay; cache okay
 		$this->assertGreaterThan( 0, $unautoloaded_widget_option_count );
+		// @codingStandardsIgnoreStop
 	}
 
 	/**

--- a/tests/test-class-non-autoloaded-widget-options.php
+++ b/tests/test-class-non-autoloaded-widget-options.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Non_Autoloaded_Widget_Options extends Base_Test_Case {
 
 	/**

--- a/tests/test-class-optimized-widget-registration.php
+++ b/tests/test-class-optimized-widget-registration.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Optimized_Widget_Registration extends Base_Test_Case {
 
 	/**

--- a/tests/test-class-plugin.php
+++ b/tests/test-class-plugin.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Plugin extends Base_Test_Case {
 
 	/**

--- a/tests/test-class-widget-number-incrementing.php
+++ b/tests/test-class-widget-number-incrementing.php
@@ -4,6 +4,11 @@ namespace CustomizeWidgetsPlus;
 
 class Test_Widget_Number_Incrementing extends Base_Test_Case {
 
+	function setUp() {
+		parent::setUp();
+		require_once __DIR__ . '/data/class-acme-widget.php';
+	}
+
 	/**
 	 * @see Widget_Number_Incrementing::__construct()
 	 */

--- a/tests/test-class-widget-number-incrementing.php
+++ b/tests/test-class-widget-number-incrementing.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Widget_Number_Incrementing extends Base_Test_Case {
 
 	function setUp() {

--- a/tests/test-class-widget-posts-with-customizer.php
+++ b/tests/test-class-widget-posts-with-customizer.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Widget_Posts_With_Customizer extends Base_Test_Case {
 
 	/**

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -718,7 +718,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 		add_action( 'widget_posts_content_moved_message', function( $args ) use ( &$success_count, &$warning_count ) {
 			if ( 'success' === $args['type'] ) {
 				$success_count += 1;
-			} else if ( 'warning' === $args['type'] ) {
+			} elseif ( 'warning' === $args['type'] ) {
 				$warning_count += 1;
 			}
 		} );

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -581,13 +581,13 @@ class Test_Widget_Posts extends Base_Test_Case {
 			$this->assertNotEmpty( $sanitized_inserted_instance );
 			$this->assertArrayHasKey( 'filter', $sanitized_inserted_instance );
 			$this->assertNotEquals( $inserted_instance, $sanitized_inserted_instance );
-			$this->assertEquals( wp_kses_post( stripslashes( $inserted_instance['text'] ) ), $sanitized_inserted_instance['text'] );
+			$this->assertEquals( wp_kses_post( $inserted_instance['text'] ), $sanitized_inserted_instance['text'] );
 
 			// Now update the same post.
 			$post_objects[] = $this->module->update_widget( $sanitized_post->post_name, $update_instance, array( 'needs_sanitization' => true ) );
 			$sanitized_updated_instance = $this->module->get_widget_instance_data( $sanitized_post->ID );
 			$this->assertNotEquals( $updated_instance, $sanitized_updated_instance );
-			$this->assertEquals( wp_kses_post( stripslashes( $update_instance['text'] ) ), $sanitized_updated_instance['text'] );
+			$this->assertEquals( wp_kses_post( $update_instance['text'] ), $sanitized_updated_instance['text'] );
 
 			// Ensure revisions are inserted as expected.
 			$post_revisions = array_values( wp_get_post_revisions( $sanitized_post, array( 'order' => 'ASC' ) ) );

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Widget_Posts extends Base_Test_Case {
 
 	/**

--- a/tests/test-class-widget-posts.php
+++ b/tests/test-class-widget-posts.php
@@ -49,36 +49,89 @@ class Test_Widget_Posts extends Base_Test_Case {
 	}
 
 	/**
+	 * @see Widget_Posts::default_config()
+	 * @see Widget_Posts::config()
+	 */
+	function test_config() {
+		$this->init_and_migrate();
+		$this->assertInternalType( 'array', Widget_Posts::default_config() );
+		$this->assertArrayHasKey( 'capability', Widget_Posts::default_config() );
+		$this->assertInternalType( 'array', $this->module->config() );
+		$this->assertArrayHasKey( 'capability', $this->module->config() );
+		$this->assertInternalType( 'string', $this->module->config( 'capability' ) );
+		$this->assertNull( $this->module->config( 'bad' ) );
+	}
+
+	/**
+	 * @see Widget_Posts::is_enabled()
+	 * @see Widget_Posts::enable()
+	 * @see Widget_Posts::disable()
+	 */
+	function test_is_enabled() {
+		$this->init_and_migrate();
+		$this->module->enable();
+		$this->assertTrue( $this->module->is_enabled() );
+		$this->module->disable();
+		$this->assertFalse( $this->module->is_enabled() );
+		$this->module->enable();
+		$this->assertTrue( $this->module->is_enabled() );
+	}
+
+	/**
 	 * @see Widget_Posts::check_widget_instance_is_empty()
 	 */
 	function test_check_widget_instance_is_empty() {
 		$widget_posts = new Widget_Posts( $this->plugin );
 
-		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( true, array( 'post_type' => 'post' ) ) );
+		$this->assertNull( $widget_posts->check_widget_instance_is_empty( null, array( 'post_type' => 'post' ) ) );
 
-		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( true, array(
+		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( null, array(
 			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
-			'post_content_filtered' => '',
+			'post_content' => '',
 		) ) );
 
-		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( true, array(
+		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( null, array(
 			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
-			'post_content_filtered' => '#### BAD',
+			'post_content' => '#### BAD',
 		) ) );
 
-		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( true, array(
+		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( null, array(
 			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
-			'post_content_filtered' => base64_encode( 'HELLO WORLD' ),
+			'post_content' => wp_slash( Widget_Posts::encode_json( 'HELLO WORLD' ) ),
 		) ) );
 
-		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( true, array(
+		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( null, array(
 			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
-			'post_content_filtered' => base64_encode( serialize( (object) array( 'foo' => 'bar' ) ) ),
+			'post_content' => wp_slash( Widget_Posts::encode_json( (object) array( 'foo' => 'bar' ) ) ),
 		) ) );
 
-		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( false, array(
+		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( null, array(
 			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
-			'post_content_filtered' => base64_encode( serialize( array( 'title' => 'hello' ) ) ),
+			'post_content' => wp_slash( Widget_Posts::encode_json( array( 'title' => 'hello \\o/' ) ) ),
+		) ) );
+		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( null, array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => Widget_Posts::encode_json( array( 'title' => 'hello \\o/' ) ),
+		) ) );
+
+		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( null, array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => wp_slash( Widget_Posts::encode_json( array() ) ),
+		) ) );
+		$this->assertFalse( $widget_posts->check_widget_instance_is_empty( null, array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => Widget_Posts::encode_json( array() ),
+		) ) );
+
+		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( null, array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => wp_slash( Widget_Posts::encode_json( array() ) ),
+			'ID' => 123,
+		) ) );
+		$this->assertTrue( $widget_posts->check_widget_instance_is_empty( null, array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => Widget_Posts::encode_json( array() ),
+			'ID' => 123,
 		) ) );
 	}
 
@@ -101,9 +154,166 @@ class Test_Widget_Posts extends Base_Test_Case {
 		$post_type_obj = $instance->register_instance_post_type();
 		$this->assertInternalType( 'object', $post_type_obj );
 		$this->assertNotEmpty( get_post_type_object( Widget_Posts::INSTANCE_POST_TYPE ) );
-		$this->assertEquals( 10, has_filter( 'wp_insert_post_data', array( $instance, 'preserve_content_filtered' ) ) );
 		$this->assertEquals( 10, has_action( 'delete_post', array( $instance, 'flush_widget_instance_numbers_cache' ) ) );
 		$this->assertEquals( 10, has_action( 'save_post_' . Widget_Posts::INSTANCE_POST_TYPE, array( $instance, 'flush_widget_instance_numbers_cache' ) ) );
+	}
+
+	/**
+	 * @see Widget_Posts::remove_add_new_submenu()
+	 */
+	function test_remove_add_new_submenu() {
+		global $submenu;
+		$module = new Widget_Posts( $this->plugin );
+		$submenu[ 'edit.php?post_type=' . Widget_Posts::INSTANCE_POST_TYPE ][10] = array();
+		$module->remove_add_new_submenu();
+		$this->assertFalse( isset( $submenu[ 'edit.php?post_type=' . Widget_Posts::INSTANCE_POST_TYPE ][10] ) );
+	}
+
+	/**
+	 * @see Widget_Posts::columns_header()
+	 */
+	function test_columns_header() {
+		$module = new Widget_Posts( $this->plugin );
+		$columns = $module->columns_header( array( 'cb' => '', 'date' => '' ) );
+		$this->assertArrayHasKey( 'title', $columns );
+		$this->assertArrayHasKey( 'widget_id', $columns );
+	}
+
+	/**
+	 * @see Widget_Posts::custom_column_row()
+	 */
+	function test_custom_column_row() {
+		$this->init_and_migrate();
+		$post = $this->module->insert_widget( 'text', array( 'text' => 'hi' ) );
+
+		ob_start();
+		$this->module->custom_column_row( 'widget_id', $post->ID );
+		$content = ob_get_clean();
+
+		$this->assertNotEmpty( $content );
+		$this->assertContains( $post->post_name, $content );
+	}
+
+	/**
+	 * @see Widget_Posts::custom_sortable_column()
+	 */
+	function test_custom_sortable_column() {
+		$module = new Widget_Posts( $this->plugin );
+		$columns = $module->custom_sortable_column( array() );
+		$this->assertArrayHasKey( 'widget_id', $columns );
+		$this->assertEquals( 'post_name', $columns['widget_id'] );
+	}
+
+	/**
+	 * @see Widget_Posts::filter_bulk_actions()
+	 */
+	function test_filter_bulk_actions() {
+		$module = new Widget_Posts( $this->plugin );
+		$actions = $module->filter_bulk_actions( array(
+			'edit' => true,
+			'trash' => true,
+		) );
+		$this->assertEmpty( $actions );
+	}
+
+	/**
+	 * @see Widget_Posts::filter_post_row_actions()
+	 */
+	function test_filter_post_row_actions() {
+		$this->init_and_migrate();
+		$actions = $this->module->filter_post_row_actions(
+			array(
+				'view' => true,
+				'trash' => true,
+				'inline hide-if-no-js' => true,
+			),
+			$this->module->get_widget_post( 'search-2' )
+		);
+		$this->assertEmpty( $actions );
+	}
+
+	/**
+	 * @see Widget_Posts::filter_posts_search()
+	 */
+	function test_filter_posts_search() {
+		$this->init_and_migrate();
+
+		// Search by ID base.
+		$query = new \WP_Query( array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			's' => 'search',
+		) );
+		$posts = $query->get_posts();
+		$this->assertCount( 1, $posts );
+		$this->assertStringStartsWith( 'search-', $posts[0]->post_name );
+
+		// Search by Widget ID.
+		$query = new \WP_Query( array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			's' => 'search-2',
+		) );
+		$posts = $query->get_posts();
+		$this->assertCount( 1, $posts );
+		$this->assertEquals( 'search-2', $posts[0]->post_name );
+
+		// Search by Widget ID.
+		$query = new \WP_Query( array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			's' => 'no-way',
+		) );
+		$posts = $query->get_posts();
+		$this->assertCount( 0, $posts );
+
+		// Search by widget content.
+		$post = $this->module->insert_widget( 'text', array(
+			'text' => 'hello my world',
+		) );
+		$query = new \WP_Query( array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			's' => 'my world',
+		) );
+		$posts = $query->get_posts();
+		$this->assertCount( 1, $posts );
+		$this->assertEquals( $post->ID, $posts[0]->ID );
+	}
+
+	/**
+	 * @filter Widget_Posts::filter_post_revision_field_post_content()
+	 */
+	function test_filter_post_revision_field_to_suppress_display() {
+		$this->init_and_migrate();
+		$post = $this->module->get_widget_post( 'search-2' );
+		$this->assertNotEmpty( $post );
+		$instance = $this->module->get_post_content( $post );
+		$instance['title'] = 'hello';
+		$this->module->update_widget( $post->post_name, $instance );
+
+		$revisions = get_posts( array(
+			'post_type' => 'revision',
+			'post_status' => 'any',
+			'post_parent' => $post->ID,
+		) );
+		$this->assertNotEmpty( $revisions );
+		$revision = array_shift( $revisions );
+
+		$this->assertInternalType( 'array', json_decode( $this->module->filter_post_revision_field_post_content( $revision->post_content, 'post_content', $revision, 'to' ), true ) );
+	}
+
+	/**
+	 * @filter Widget_Posts::setup_metaboxes()
+	 */
+	function test_setup_metaboxes() {
+		global $wp_meta_boxes;
+		$module = new Widget_Posts( $this->plugin );
+		$id = 'widget_instance';
+		$screen = convert_to_screen( Widget_Posts::INSTANCE_POST_TYPE );
+		$page = $screen->id;
+		$context = 'normal';
+		$priority = 'high';
+
+		$this->assertTrue( empty( $wp_meta_boxes[ $page ][ $context ][ $priority ][ $id ] ) );
+		$module->setup_metaboxes();
+		$this->assertFalse( empty( $wp_meta_boxes[ $page ][ $context ][ $priority ][ $id ] ) );
 	}
 
 	/**
@@ -136,7 +346,7 @@ class Test_Widget_Posts extends Base_Test_Case {
 			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
 			$this->assertEquals( "$id_base-$widget_number", $post->post_name );
 
-			$this->assertEquals( $original_instances[ $widget_number ], Widget_Posts::get_post_content_filtered( $post ) );
+			$this->assertEquals( $original_instances[ $widget_number ], Widget_Posts::get_post_content( $post ) );
 		}
 
 		// Before any Widget_Settings::offsetGet() gets called, try iterating
@@ -155,32 +365,523 @@ class Test_Widget_Posts extends Base_Test_Case {
 		$this->assertEquals( 0, did_action( 'update_option_widget_meta' ), 'Expected update_option( "widget_meta" ) to short-circuit.' );
 	}
 
-	function test_update_post_id_lookup_cache_on_save_post() {
+	/**
+	 * @see Widget_Posts::get_widget_post()
+	 */
+	function test_get_widget_post() {
 		$this->init_and_migrate();
-		$post = $this->module->insert_widget( 'search', array( 'title' => 'Hi' ) );
-		$this->assertEquals( $post->ID, wp_cache_get( $post->post_name, Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
+
+		$instance = array(
+			'title' => '\\o/',
+			'text' => 'Hello.',
+		);
+
+		$post_stati = array( 'publish', 'private', 'draft', 'trash' );
+		$post_array = array(
+			'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_status' => 'publish',
+		);
+
+		foreach ( $post_stati as $i => $post_status ) {
+			$post_name = sprintf( 'text-%d', $i + 10 );
+			$post_id = wp_insert_post( array_merge( $post_array, compact( 'post_status', 'post_name' ) ) );
+			$widget_id = $post_name;
+
+			$widget_post = $this->module->get_widget_post( $widget_id );
+			$this->assertInstanceOf( '\WP_Post', $widget_post, "Expected to find widget post for status $post_status." );
+			$this->assertEquals( $post_id, $widget_post->ID );
+		}
 	}
 
-	function test_clear_post_id_lookup_cache_on_delete_post() {
-		$this->init_and_migrate();
-		$post = $this->module->insert_widget( 'search', array( 'title' => 'Hi' ) );
-		$this->assertEquals( $post->ID, wp_cache_get( $post->post_name, Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
-		wp_delete_post( $post->ID, true );
-		$this->assertEquals( 0, wp_cache_get( "$post->post_name", Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
+	/**
+	 * @see Widget_Posts::get_widget_instance_data()
+	 */
+	function test_get_widget_instance_data() {
+		$instance = array(
+			'title' => '\\o/',
+			'text' => 'Hello.',
+		);
+		$widget_id = 'text-125';
+
+		$post_id = wp_insert_post( array(
+			'post_name' => $widget_id,
+			'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_status' => 'publish',
+		) );
+		$this->assertNotEmpty( $post_id );
+
+		$module = new Widget_Posts( $this->plugin );
+
+		// Get widget instance data by post ID.
+		$saved_instance1 = $module->get_widget_instance_data( $post_id );
+		$this->assertEquals( $instance, $saved_instance1 );
+
+		// Get widget instance by WP_Post.
+		$saved_instance2 = $module->get_widget_instance_data( get_post( $post_id ) );
+		$this->assertEquals( $instance, $saved_instance2 );
+
+		// Get widget instance by widget ID.
+		$saved_instance3 = $module->get_widget_instance_data( $widget_id );
+		$this->assertEquals( $instance, $saved_instance3 );
 	}
 
-	function test_delete_post_id_lookup_cache_on_pre_post_update() {
+	/**
+	 * @see Widget_Posts::get_post_content()
+	 */
+	function test_get_post_content() {
+		global $wpdb;
 		$this->init_and_migrate();
-		$post = $this->module->insert_widget( 'search', array( 'title' => 'Hi' ) );
-		$this->assertEquals( $post->ID, wp_cache_get( $post->post_name, Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
 
-		$old_post_name = $post->post_name;
-		$new_post_name = $post->post_name . '123';
-		$post_data = $post->to_array();
-		$post_data['post_name'] = $new_post_name;
-		wp_insert_post( $post_data );
+		$defaults = array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_status' => 'publish',
+		);
 
-		$this->assertEmpty( wp_cache_get( $old_post_name, Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
-		$this->assertEquals( $post->ID, wp_cache_get( $new_post_name, Widget_Posts::POST_NAME_TO_POST_ID_CACHE_GROUP ) );
+		/*
+		 * The post_content_filtered used to be revisioned. Note that in spite of
+		 * doing this here, it may actually fail to store the post_content_filtered
+		 * later because \_wp_post_revision_fields() uses a static var for storing the
+		 * revision fields. So this is why you see below that WPDB::update() is
+		 * also called.
+		 */
+		add_filter( '_wp_post_revision_fields', function( $fields ) {
+			$fields['post_content_filtered'] = 'Raw';
+			return $fields;
+		} );
+
+		$instance = array(
+			'title' => '\\o/',
+			'text' => 'Hello.',
+		);
+
+		// Test legacy storage in post_content_filtered only.
+		$widget_id = 'text-123';
+		$post_content_filtered = base64_encode( serialize( $instance ) );
+		$wpdb->insert( $wpdb->posts, array_merge( $defaults, array(
+			'post_name' => $widget_id,
+			'post_title' => 'food',
+			'post_content' => '',
+			'post_content_filtered' => base64_encode( serialize( $instance ) ),
+		) ) ); // WPCS: db call ok.
+		$post_id = $wpdb->insert_id;
+		$this->assertNotEmpty( $post_id );
+		$saved_instance = Widget_Posts::get_post_content( get_post( $post_id ) );
+		$this->assertEquals( $instance, $saved_instance );
+		$revision_post_id = _wp_put_post_revision( $post_id );
+		$wpdb->update( $wpdb->posts, compact( 'post_content_filtered' ), array( 'ID' => $revision_post_id ) ); // WPCS: db call ok. Cache ok.
+		clean_post_cache( $revision_post_id ); // See comment above with _wp_post_revision_fields filter for why.
+		$revision_post = get_post( $revision_post_id );
+		$this->assertNotEmpty( $revision_post->post_content_filtered );
+		$this->assertInternalType( 'int', $revision_post_id );
+		$saved_revision_instance = Widget_Posts::get_post_content( get_post( $revision_post_id ) );
+		$this->assertEquals( $saved_instance, $saved_revision_instance );
+
+		// Test legacy storage in post_content_filtered, after importing via WP Importer.
+		$widget_id = 'text-124';
+		$post_content_filtered = base64_encode( serialize( $instance ) );
+		$post_id = wp_insert_post( array_merge( $defaults, array(
+			'post_name' => $widget_id,
+			'post_content' => wp_slash( Widget_Posts::encode_json( array_merge( $instance, array( 'title' => 'Not Canonical' ) ) ) ),
+			'post_content_filtered' => $post_content_filtered,
+		) ) );
+		$this->assertNotEmpty( $post_id );
+		$saved_instance = Widget_Posts::get_post_content( get_post( $post_id ) );
+		$this->assertEquals( $instance, $saved_instance );
+		$revision_post_id = _wp_put_post_revision( $post_id );
+		$wpdb->update( $wpdb->posts, compact( 'post_content_filtered' ), array( 'ID' => $revision_post_id ) ); // WPCS: db call ok. Cache ok.
+		$this->assertInternalType( 'int', $revision_post_id );
+		clean_post_cache( $revision_post_id ); // See comment above with _wp_post_revision_fields filter for why.
+		$saved_revision_instance = Widget_Posts::get_post_content( get_post( $revision_post_id ) );
+		$this->assertEquals( $saved_instance, $saved_revision_instance );
+
+		// Test new storage of JSON directly in post_content.
+		$widget_id = 'text-125';
+		$post_id = wp_insert_post( array_merge( $defaults, array(
+			'post_name' => $widget_id,
+			'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+		) ) );
+		$this->assertNotEmpty( $post_id );
+		$saved_instance = Widget_Posts::get_post_content( get_post( $post_id ) );
+		$this->assertEquals( $instance, $saved_instance );
+		$revision_post_id = _wp_put_post_revision( $post_id );
+		$this->assertInternalType( 'int', $revision_post_id );
+		$saved_revision_instance = Widget_Posts::get_post_content( get_post( $revision_post_id ) );
+		$this->assertEquals( $saved_instance, $saved_revision_instance );
+
+		// This should return nothing since it is not a valid post type.
+		$widget_id = 'text-126';
+		$post_id = wp_insert_post( array_merge( $defaults, array(
+			'post_type' => 'post',
+			'post_name' => $widget_id,
+			'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+		) ) );
+		$this->assertNotEmpty( $post_id );
+		$this->assertEmpty( Widget_Posts::get_post_content( get_post( $post_id ) ) );
+	}
+
+	/**
+	 * @see Widget_Posts::insert_widget()
+	 * @see Widget_Posts::update_widget()
+	 */
+	function test_insert_and_update_widget() {
+		$this->init_and_migrate();
+		kses_init_filters();
+		$this->assertFalse( current_user_can( 'unfiltered_html' ) );
+
+		$default_instance = array(
+			'text' => '<script>document.write("hello \\\\o/" + \'\\o/\');</script>',
+		);
+		$instances = array(
+			array( 'title' => 'Yay \o/' ),
+			array( 'title' => 'Yay \\o//' ),
+			array( 'title' => 'Yay \\\\o///' ),
+			array( 'title' => 'Yay \\' ),
+		);
+		$post_objects = array();
+		foreach ( $instances as $instance ) {
+			$instance = array_merge( $default_instance, $instance );
+
+			/*
+			 * Test without sanitization (e.g. import)
+			 */
+			$post = $this->module->insert_widget( 'text', $instance, array( 'needs_sanitization' => false ) );
+			$post_objects[] = $post;
+
+			$inserted_instance = $this->module->get_widget_instance_data( $post );
+			$this->assertEquals( $instance, $inserted_instance, $instance['title'] );
+			$this->assertArrayNotHasKey( 'filter', $instance );
+			$this->assertEquals( $instance['title'], $post->post_title );
+
+			// Now update the same post.
+			$update_instance = $instance;
+			$update_instance['text'] .= '<script>hello.world()</script>';
+			$post = $this->module->update_widget( $post->post_name, $update_instance, array( 'needs_sanitization' => false ) );
+			$post_objects[] = $post;
+			$updated_instance = $this->module->get_widget_instance_data( $post->ID );
+			$this->assertEquals( $update_instance, $updated_instance );
+			$this->assertStringStartsWith( 'text-', $post->post_name );
+
+			// Ensure revisions are inserted as expected.
+			$post_revisions = array_values( wp_get_post_revisions( $post, array( 'order' => 'ASC' ) ) );
+			$this->assertCount( 2, $post_revisions );
+			$this->assertEquals( $inserted_instance, json_decode( $post_revisions[0]->post_content, true ) );
+			$this->assertEquals( $updated_instance, json_decode( $post_revisions[1]->post_content, true ) );
+
+			/*
+			 * Test with sanitization
+			 */
+			$sanitized_post = $this->module->insert_widget( 'text', $instance, array( 'needs_sanitization' => true ) );
+			$post_objects[] = $sanitized_post;
+			$sanitized_inserted_instance = $this->module->get_widget_instance_data( $sanitized_post );
+			$this->assertNotEmpty( $sanitized_inserted_instance );
+			$this->assertArrayHasKey( 'filter', $sanitized_inserted_instance );
+			$this->assertNotEquals( $inserted_instance, $sanitized_inserted_instance );
+			$this->assertEquals( wp_kses_post( stripslashes( $inserted_instance['text'] ) ), $sanitized_inserted_instance['text'] );
+
+			// Now update the same post.
+			$post_objects[] = $this->module->update_widget( $sanitized_post->post_name, $update_instance, array( 'needs_sanitization' => true ) );
+			$sanitized_updated_instance = $this->module->get_widget_instance_data( $sanitized_post->ID );
+			$this->assertNotEquals( $updated_instance, $sanitized_updated_instance );
+			$this->assertEquals( wp_kses_post( stripslashes( $update_instance['text'] ) ), $sanitized_updated_instance['text'] );
+
+			// Ensure revisions are inserted as expected.
+			$post_revisions = array_values( wp_get_post_revisions( $sanitized_post, array( 'order' => 'ASC' ) ) );
+			$this->assertCount( 2, $post_revisions );
+			$this->assertEquals( $sanitized_inserted_instance, json_decode( $post_revisions[0]->post_content, true ) );
+			$this->assertEquals( $sanitized_updated_instance, json_decode( $post_revisions[1]->post_content, true ) );
+		}
+
+		foreach ( $post_objects as $post ) {
+			$this->assertStringStartsNotWith( '0000-00-00', $post->post_date );
+			$this->assertStringStartsNotWith( '0000-00-00', $post->post_modified );
+			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
+			$this->assertEmpty( $post->post_excerpt );
+			$this->assertEquals( 'publish', $post->post_status );
+			$this->assertEmpty( $post->post_content_filtered );
+		}
+	}
+
+	/**
+	 * @see Widget_Posts::insert_widget()
+	 */
+	function test_unserializable_instance() {
+		$this->init_and_migrate();
+
+		$bad_instances = array();
+
+		// Make sure failure when inserting non-JSON serializable arrays.
+		$turtle = new \stdClass();
+		$turtle->turtle = &$turtle;
+		$bad_instances[] = array(
+			'title' => 'recursion',
+			'text' => $turtle,
+		);
+		$bad_instances[] = array(
+			'title' => 'fo',
+			'text' => (object) array( 'a' => 'b' ),
+		);
+		$bad_instances[] = array(
+			'wpdb' => $GLOBALS['wpdb'],
+		);
+
+		foreach ( $bad_instances as $instance ) {
+			$exception = null;
+			try {
+				$this->module->insert_widget( 'text', $instance, array( 'needs_sanitization' => false ) );
+			} catch ( \Exception $e ) {
+				$exception = $e;
+			}
+			$this->assertNotEmpty( $exception );
+		}
+	}
+
+	/**
+	 * Test fundamental concepts in how the widget instance data is stored.
+	 */
+	function test_storage_mechanics() {
+		global $wpdb;
+
+		$default_instance = array(
+			'text' => '<script>document.write("hello \\o/" + \'\\o/\');</script>',
+		);
+
+		// @todo Make sure that content_save_pre gets applied before wp_insert_post_data.
+
+		$instances = array(
+			array( 'title' => 'Yay \o/' ),
+			array( 'title' => 'Yay " \' \o/' ),
+			array( 'title' => 'Yay \\o//' ),
+			array( 'title' => 'Yay \\\\o///' ),
+			array( 'title' => 'Yay \\' ),
+			array( 'title' => "Yay \x00" ),
+		);
+		$widget_number = 1;
+		kses_remove_filters(); // @todo This has to be removable.
+		foreach ( $instances as $instance ) {
+			$instance = array_merge( $default_instance, $instance );
+
+			$widget_number += 1;
+			$post_id = wp_insert_post( array(
+				'title' => $instance['title'],
+				'post_name' => "text-$widget_number",
+				'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+				'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+			) );
+			$this->assertInternalType( 'int', $post_id );
+			$post = get_post( $post_id );
+			$decoded = json_decode( $post->post_content, true );
+			$this->assertEquals( $decoded, $instance );
+			$raw_data = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) ); // WPCS: db call ok; cache ok.
+			$this->assertEquals( $instance, json_decode( $raw_data, true ) );
+		}
+	}
+
+	/**
+	 * @see Widget_Posts::move_encoded_data_to_post_content()
+	 */
+	function test_move_encoded_data_to_post_content() {
+		$this->init_and_migrate();
+
+		$post_arrays = array(
+			// Test widget instance added via insert_widget().
+			array(
+				'post_title' => 'test',
+				'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+				'post_name' => 'search-10',
+				'post_content' => '',
+				'post_content_filtered' => base64_encode( serialize( array( 'title' => 'test \\ "me"' ) ) ),
+			),
+			// Test widget instance added via WordPress Importer under WordPress 4.3.
+			array(
+				'post_title' => 'test',
+				'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+				'post_name' => 'search-11',
+				'post_content' => wp_slash( Widget_Posts::encode_json( array( 'title' => 'hello' ) ) ),
+				'post_content_filtered' => base64_encode( serialize( array( 'title' => 'hello' ) ) ),
+			),
+		);
+
+		// Insert post using old storage mechanism.
+		$original_posts = array();
+		remove_filter( 'wp_insert_post_empty_content', array( $this->module, 'check_widget_instance_is_empty' ), 10 );
+		foreach ( $post_arrays as $post_arr ) {
+			$post_id = wp_insert_post( $post_arr );
+			$this->assertNotEmpty( $post_id );
+			$original_posts[ $post_id ] = get_post( $post_id );
+		}
+		add_filter( 'wp_insert_post_empty_content', array( $this->module, 'check_widget_instance_is_empty' ), 10, 2 );
+
+		$success_count = 0;
+		$warning_count = 0;
+		add_action( 'widget_posts_content_moved_message', function( $args ) use ( &$success_count, &$warning_count ) {
+			if ( 'success' === $args['type'] ) {
+				$success_count += 1;
+			} else if ( 'warning' === $args['type'] ) {
+				$warning_count += 1;
+			}
+		} );
+
+		$this->module->move_encoded_data_to_post_content( array(
+			'dry-run' => true,
+			'sleep-interval' => 0,
+			'sleep-duration' => 0,
+		) );
+
+		$this->assertEquals( 2, $success_count );
+		$this->assertEquals( 0, $warning_count );
+
+		foreach ( $original_posts as $post_id => $old_post ) {
+			$check_post = get_post( $post_id );
+			$this->assertEquals( $old_post, $check_post );
+			$this->assertEmpty( get_post_meta( $post_id, '_widget_post_previous_data', true ) );
+		}
+
+		$success_count = 0;
+		$this->module->move_encoded_data_to_post_content( array(
+			'dry-run' => false,
+			'sleep-interval' => 0,
+			'sleep-duration' => 0,
+		) );
+		$this->assertEquals( 2, $success_count );
+		$this->assertEquals( 0, $warning_count );
+
+		foreach ( $original_posts as $post_id => $old_post ) {
+			$check_post = get_post( $post_id );
+			$this->assertNotEquals( $old_post, $check_post );
+			$this->assertNotEmpty( $check_post->post_content );
+			$instance = json_decode( $check_post->post_content, true );
+			$this->assertInternalType( 'array', $instance );
+			$this->assertEmpty( $check_post->post_content_filtered );
+			$this->assertNotEmpty( $check_post->post_content );
+			$this->assertEquals( unserialize( base64_decode( $old_post->post_content_filtered ) ), $instance );
+			$backup = get_post_meta( $post_id, '_widget_post_previous_data', true );
+			$this->assertNotEmpty( $backup );
+			$this->assertEquals( $old_post, unserialize( base64_decode( $backup ) ) );
+		}
+	}
+
+	/**
+	 * Check importing from WXR that encoded widget instance data in base64-encoded PHP-serialized string.
+	 *
+	 * @see Widget_Posts::filter_wp_import_post_data_processed()
+	 */
+	function test_filter_wp_import_post_data_processed() {
+		$this->init_and_migrate();
+
+		$instance = array( 'title' => 'Hi \o/', 'text' => 'Here is "text". More \'quotes\'. <script>alert(1)</script>' );
+
+		// Make sure that initially-encoded base64-encoded PHP-serialized data gets honored.
+		$postdata = apply_filters( 'wp_import_post_data_processed', array(
+			'post_name' => 'text-3',
+			'post_content' => base64_encode( serialize( $instance ) ),
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+		) );
+		$this->assertEquals( $instance, json_decode( base64_decode( $postdata['post_content'] ), true ) );
+		$r = wp_insert_post( $postdata, true );
+		$this->assertNotInstanceOf( '\WP_Error', $r, $r instanceof \WP_Error ? $r->get_error_message() : null );
+		$this->assertNotEmpty( $r );
+		$post = get_post( $r );
+		$this->assertEquals( $instance, json_decode( $post->post_content, true ) );
+
+		// Make sure that initially-JSON content gets encoded as base64 so that wp_insert_post() won't trip.
+		$postdata = apply_filters( 'wp_import_post_data_processed', array(
+			'post_name' => 'text-4',
+			'post_content' => json_encode( $instance ),
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+		) );
+		$this->assertEquals( $instance, json_decode( base64_decode( $postdata['post_content'] ), true ) );
+		$r = wp_insert_post( $postdata, true );
+		$this->assertNotInstanceOf( '\WP_Error', $r, $r instanceof \WP_Error ? $r->get_error_message() : null );
+		$this->assertNotEmpty( $r );
+		$post = get_post( $r );
+		$this->assertEquals( $instance, json_decode( $post->post_content, true ) );
+	}
+
+	/**
+	 * @see Widget_Posts::filter_wp_insert_post_data()
+	 */
+	function test_filter_wp_insert_post_data() {
+		$this->init_and_migrate();
+		$instance = array( 'title' => 'Hi \o/', 'text' => 'Here is "text". More \'quotes\'.', 'filter' => false );
+		$unslashed_json = Widget_Posts::encode_json( $instance );
+		$slashed_json = wp_slash( Widget_Posts::encode_json( $instance ) );
+
+		$post_arr = array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => $unslashed_json,
+		);
+		$data = apply_filters( 'wp_insert_post_data', $post_arr, $post_arr );
+		$this->assertEquals( $instance, json_decode( wp_unslash( $data['post_content'] ), true ) );
+
+		$post_arr = array(
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => $slashed_json,
+		);
+		$data = apply_filters( 'wp_insert_post_data', $post_arr, $post_arr );
+		$this->assertEquals( $instance, json_decode( wp_unslash( $data['post_content'] ), true ) );
+	}
+
+	/**
+	 * Ensure that we can post JSON right in as post_content if we slash it and remove kses filters.
+	 */
+	function test_wp_insert_post() {
+		$this->init_and_migrate();
+		kses_remove_filters(); // This is required
+		$instance = array( 'title' => 'Hi \o/', 'text' => 'Here is "text". More \'quotes\'.<script>alert(1)</script>', 'filter' => false );
+
+		$r = wp_insert_post( array(
+			'post_name' => 'text-2',
+			'post_type' => Widget_Posts::INSTANCE_POST_TYPE,
+			'post_content' => wp_slash( Widget_Posts::encode_json( $instance ) ),
+		), true );
+		$this->assertNotInstanceOf( '\WP_Error', $r, $r instanceof \WP_Error ? $r->get_error_message() : '' );
+		$post = get_post( $r );
+		$this->assertEquals( $instance, json_decode( $post->post_content, true ) );
+	}
+
+	/**
+	 * Make sure that wp_update_post() doesn't corrupt a widget instance containing JSON with strings with escapes.
+	 */
+	function test_wp_update_post() {
+		$this->init_and_migrate();
+		$instance = array( 'title' => 'Hi \o/', 'text' => 'Here is "text". More \'quotes\'.', 'filter' => false );
+		$post = $this->module->insert_widget( 'text', $instance );
+
+		$r = wp_update_post( array(
+			'ID' => $post->ID,
+			'post_excerpt' => 'Test',
+		) );
+		$this->assertEquals( $r, $post->ID );
+		$updated_post = get_post( $r );
+
+		$updated_instance = json_decode( $updated_post->post_content, true );
+		$this->assertEquals( $instance, $updated_instance );
+	}
+
+	/**
+	 * @see \CustomizeWidgetsPlus\Widget_Posts::handle_legacy_content_export
+	 */
+	function test_handle_legacy_content_export() {
+		$this->init_and_migrate();
+		$instance = array( 'title' => 'Foo & Bar', 'text' => 'Lorem Ipsum \\o/', 'filter' => false );
+		$post = $this->module->insert_widget( 'text', $instance, array( 'needs_sanitization' => false ) );
+		$this->assertEquals( $instance, json_decode( $post->post_content, true ) );
+
+		// Update the post to look like a legacy post.
+		$post_arr = $post->to_array();
+		$post_arr['post_content_filtered'] = base64_encode( serialize( $instance ) );
+		$post_arr['post_content'] = wp_kses_post( Widget_Posts::encode_json( $instance ) );
+		wp_update_post( wp_slash( $post_arr ) );
+		$post = get_post( $post_arr['ID'] );
+
+		// Simulate logic for exporting the post.
+		$GLOBALS['post'] = $post;
+		setup_postdata( $post );
+		$post_content = apply_filters( 'the_content_export', $post->post_content );
+
+		$this->assertNotEquals( $post->post_content, $post_content );
+		$this->assertEquals( $instance, json_decode( $post_content, true ) );
 	}
 }

--- a/tests/test-class-widget-settings.php
+++ b/tests/test-class-widget-settings.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Widget_Settings extends Base_Test_Case {
 
 	function setUp() {

--- a/tests/test-class-widget-settings.php
+++ b/tests/test-class-widget-settings.php
@@ -108,7 +108,7 @@ class Test_Widget_Settings extends Base_Test_Case {
 		foreach ( $settings as $widget_number => $instance ) {
 			$this->assertInternalType( 'array', $instance );
 			$this->assertContains( 'widget_posts', $instance['title'] );
-			$this->assertEquals( $instance, Widget_Posts::get_post_content_filtered( get_post( $shallow_settings[ $widget_number ] ) ) );
+			$this->assertEquals( $instance, Widget_Posts::get_post_content( get_post( $shallow_settings[ $widget_number ] ) ) );
 		}
 	}
 }

--- a/tests/test-class-wp-customize-widget-setting.php
+++ b/tests/test-class-wp-customize-widget-setting.php
@@ -2,6 +2,9 @@
 
 namespace CustomizeWidgetsPlus;
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_WP_Customize_Widget_Setting extends Base_Test_Case {
 
 	/**

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -45,7 +45,7 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 		if ( $this->js_concat_init_priority ) {
 			remove_action( 'init', 'js_concat_init', $this->js_concat_init_priority );
 		}
-		global $wp_registered_widget_updates, $wp_registered_widget_controls, $wp_registered_widgets;
+
 		$wp_registered_widget_updates = array();
 		$wp_registered_widget_controls = array();
 		$wp_registered_widgets = array();
@@ -75,7 +75,10 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.
 		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 		$this->plugin->widget_posts->capture_widget_settings_for_customizer(); // Normally called in widgets_init
+	}
 
+	function test_register_widget() {
+		global $wp_registered_widget_updates, $wp_registered_widget_controls, $wp_registered_widgets;
 		$wp_registered_widgets = array();
 		$wp_registered_widget_updates = array();
 		$wp_registered_widget_controls = array();

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -24,11 +24,14 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 	 */
 	protected $js_concat_init_priority;
 
+	protected $backup_registered_widget_controls;
+	protected $backup_registered_widget_updates;
+
 	/**
 	 * Set up.
 	 */
 	function setUp() {
-		global $wp_widget_factory;
+		global $wp_widget_factory, $wp_registered_widget_updates, $wp_registered_widget_controls, $wp_registered_widgets;
 
 		// For why these hooks have to be removed, see https://github.com/Automattic/nginx-http-concat/issues/5
 		$this->css_concat_init_priority = has_action( 'init', 'css_concat_init' );
@@ -69,6 +72,16 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 		$this->plugin->widget_posts->prepare_widget_data(); // Has to be called here because of wp_widgets_init() footwork done above.
 		$this->plugin->widget_posts->register_instance_post_type(); // Normally called at init action.
 		$this->plugin->widget_posts->capture_widget_settings_for_customizer(); // Normally called in widgets_init
+
+		$wp_registered_widgets = array();
+		$wp_registered_widget_updates = array();
+		$wp_registered_widget_controls = array();
+
+		register_widget( 'WP_Widget_Search' );
+		wp_widgets_init();
+		$this->assertArrayHasKey( 'search-2', $wp_registered_widgets );
+		$this->assertArrayHasKey( 'search', $wp_registered_widget_updates );
+		$this->assertArrayHasKey( 'search-2', $wp_registered_widget_controls );
 	}
 
 	function test_register_settings() {

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -7,6 +7,9 @@ if ( ! getenv( 'WP_TESTS_DIR' ) ) {
 }
 require_once getenv( 'WP_TESTS_DIR' ) . '/tests/customize/widgets.php';
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_Widgets {
 
 	/**

--- a/tests/test-core-customize-widgets-with-widget-posts.php
+++ b/tests/test-core-customize-widgets-with-widget-posts.php
@@ -91,7 +91,6 @@ class Test_Core_Customize_Widgets_With_Widget_Posts extends \Tests_WP_Customize_
 	}
 
 	function test_register_settings() {
-		wp_widgets_init();
 		parent::test_register_settings();
 		$this->assertInstanceOf( __NAMESPACE__ . '\\WP_Customize_Widget_Setting', $this->manager->get_setting( 'widget_categories[2]' ) );
 		$this->assertEquals( 'widget', $this->manager->get_setting( 'widget_categories[2]' )->type );

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -107,7 +107,7 @@ class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 		$deleted_widget_id = null;
 		add_action( 'delete_post', function( $post_id ) use ( &$deleted_widget_id ) {
 			$post = get_post( $post_id );
-			$this->assertEquals( Widget_Posts::INSTANCE_POST_TYPE, $post->post_type );
+			$this->assertContains( $post->post_type, array( Widget_Posts::INSTANCE_POST_TYPE, 'revision' ) );
 			$deleted_widget_id = $post->post_name;
 		}, 10, 2 );
 

--- a/tests/test-core-widgets-with-widget-posts.php
+++ b/tests/test-core-widgets-with-widget-posts.php
@@ -7,6 +7,9 @@ if ( ! getenv( 'WP_TESTS_DIR' ) ) {
 }
 require_once getenv( 'WP_TESTS_DIR' ) . '/tests/widgets.php';
 
+/**
+ * @group customize-widgets-plus
+ */
 class Test_Core_With_Widget_Posts extends \Tests_Widgets {
 
 	/**


### PR DESCRIPTION
Rework widget_instance post to store instance data in post_content as JSON.
- Add move-encoded-data-to-post-content WP-CLI command for migrating post content.
- Add searching widget_instance posts by widget ID base and widget ID.
- Improve revisions for widget_instance posts.
- Hide Add New button on post listing and edit posts pages.
- Clean up PHPCS issues.

Fix unit tests, update for 4.5.
